### PR TITLE
Remove console.log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const bs = require("browser-sync")
 const Output = require('./generators/output')
 
 const self = module.exports = {
-  render: async (html, options) => Output.toString(html, options).catch(err => console.error(err)),
+  render: async (html, options) => Output.toString(html, options),
   build: async env => {
     env = env || 'local'
     let start = new Date()


### PR DESCRIPTION
Instead of logging the exception, it should be thrown so it can be properly handled.