### PR TITLE
Refactor inheritance

### DIFF
--- a/src/generators/output/toString.js
+++ b/src/generators/output/toString.js
@@ -71,6 +71,12 @@ module.exports = async (str, options) => {
     html = `{% extends "${config.layout}" %}\n${html}`
     html = nunjucks.renderString(html, { page: config, env: options.env, css: compiledCSS })
 
+    while (fm(html).attributes.layout) {
+      const front = fm(html)
+      html = `{% extends "${front.attributes.layout}" %}\n{% block template %}${front.body}{% endblock %}`
+      html = nunjucks.renderString(html, { page: config, env: options.env, css: compiledCSS })
+    }
+
     html = html
       // replace \/ in class names from head
       .replace(/(\..+-)(\w+)(\\\/)/g, '$1$2-')

--- a/src/generators/output/toString.js
+++ b/src/generators/output/toString.js
@@ -31,6 +31,7 @@ module.exports = async (str, options) => {
     let html = frontMatter.body
 
     const config = maizzleConfig.isMerged ? maizzleConfig : deepmerge(maizzleConfig, frontMatter.attributes)
+    const layout = config.layout || config.build.layout
 
     if (typeof options.afterConfig === 'function') {
       await options.afterConfig(config)
@@ -46,9 +47,9 @@ module.exports = async (str, options) => {
       // replace : in css classes from body
       html = html.replace(/("|\s\w+?)(:)/g, '$1-')
 
-      await fs.ensureFile(config.layout)
+      await fs.ensureFile(layout)
         .then(async () => {
-          const tailwindHTML = await fs.readFile(path.resolve(process.cwd(), config.layout), 'utf8') + html
+          const tailwindHTML = await fs.readFile(path.resolve(process.cwd(), layout), 'utf8') + html
           tailwindConfig.separator = '-'
           compiledCSS = await Tailwind.fromString(postCSS, tailwindHTML, tailwindConfig, maizzleConfig).catch(err => { console.log(err); process.exit() })
         })
@@ -68,7 +69,7 @@ module.exports = async (str, options) => {
       await options.beforeRender(nunjucks, config)
     }
 
-    html = `{% extends "${config.layout}" %}\n${html}`
+    html = `{% extends "${layout}" %}\n${html}`
     html = nunjucks.renderString(html, { page: config, env: options.env, css: compiledCSS })
 
     while (fm(html).attributes.layout) {


### PR DESCRIPTION
This PR refactors the template inheritance to work properly in both CLI and Node.

For any Template1 being `extend`ed by a Template2, you need to make sure to specify the `layout` to extend in Template1.

Also, in order for Maizzle to recursively compile nested Template extends, your Layouts and Templates must use the `{% block template %}{% endblock %}` tag.