### PR TITLE
Allow customizing purgeCSS "content" when building strings

### DIFF
--- a/src/generators/tailwind.js
+++ b/src/generators/tailwind.js
@@ -60,7 +60,7 @@ module.exports = {
       const tailwindPlugin = typeof tailwindConfig === 'object' ? tailwind(tailwindConfig) : tailwind()
 
       const extractor = maizzleConfig.cleanup.purgeCSS.extractor || /[\w-/:]+(?<!:)/g
-      const purgeContent = maizzleConfig.cleanup.purgeCSS.content || [];
+      const purgeContent = maizzleConfig.cleanup.purgeCSS.content || []
       const purgeWhitelist = maizzleConfig.cleanup.purgeCSS.whitelist || []
       const purgewhitelistPatterns = maizzleConfig.cleanup.purgeCSS.whitelistPatterns || []
 

--- a/src/generators/tailwind.js
+++ b/src/generators/tailwind.js
@@ -60,6 +60,7 @@ module.exports = {
       const tailwindPlugin = typeof tailwindConfig === 'object' ? tailwind(tailwindConfig) : tailwind()
 
       const extractor = maizzleConfig.cleanup.purgeCSS.extractor || /[\w-/:]+(?<!:)/g
+      const purgeContent = maizzleConfig.cleanup.purgeCSS.content || [];
       const purgeWhitelist = maizzleConfig.cleanup.purgeCSS.whitelist || []
       const purgewhitelistPatterns = maizzleConfig.cleanup.purgeCSS.whitelistPatterns || []
 
@@ -67,7 +68,10 @@ module.exports = {
         postcssNested(),
         tailwindPlugin,
         purgecss({
-          content: [{ raw: html }],
+          content: [
+            ...purgeContent,
+            { raw: html }
+          ],
           defaultExtractor: content => content.match(extractor) || [],
           whitelist: purgeWhitelist,
           whitelistPatterns: purgewhitelistPatterns


### PR DESCRIPTION
Maizzle.render() uses the config's purgeCSS "content", on the same way as it uses purgeCSS "whitelist", etc.