### PR TITLE
Include ui browser sync option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const self = module.exports = {
             baseDir: config.build.destination.path,
             directory: config.browsersync.directory
           },
+          ui: config.browsersync.ui,
           port: config.browsersync.port || 3000,
           notify: config.browsersync.notify,
           tunnel: config.browsersync.tunnel,

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const self = module.exports = {
             baseDir: config.build.destination.path,
             directory: config.browsersync.directory
           },
-          ui: config.browsersync.ui,
+          ui: config.browsersync.ui || {port: 3001},
           port: config.browsersync.port || 3000,
           notify: config.browsersync.notify,
           tunnel: config.browsersync.tunnel,


### PR DESCRIPTION
This allows specifying a custom UI port (to mirror the ability to change the default port) or disabling the UI entirely.

See https://browsersync.io/docs/options#option-ui