### PR TITLE
Fix Nunjucks inheritance.

### DIFF
--- a/src/generators/output/toString.js
+++ b/src/generators/output/toString.js
@@ -28,7 +28,6 @@ module.exports = async (str, options) => {
     let html = frontMatter.body
 
     const config = maizzleConfig.isMerged ? maizzleConfig : deepmerge(maizzleConfig, frontMatter.attributes)
-    const layout = config.layout || config.build.layout
 
     if (typeof options.afterConfig === 'function') {
       await options.afterConfig(config)
@@ -55,17 +54,7 @@ module.exports = async (str, options) => {
       await options.beforeRender(nunjucks, config)
     }
 
-    const blockStart = config.build.nunjucks && config.build.nunjucks.tags ? config.build.nunjucks.tags.blockStart : '{%'
-    const blockEnd = config.build.nunjucks && config.build.nunjucks.tags ? config.build.nunjucks.tags.blockEnd : '%}'
-
-    html = layout ? `${blockStart} extends "${layout}" ${blockEnd}\n${html}` : html
     html = nunjucks.renderString(html, { page: config, env: options.env, css: compiledCSS })
-
-    while (fm(html).attributes.layout) {
-      const front = fm(html)
-      html = `${blockStart} extends "${front.attributes.layout}" ${blockEnd}\n${blockStart} block template ${blockEnd}${front.body}${blockStart} endblock ${blockEnd}`
-      html = nunjucks.renderString(html, { page: config, env: options.env, css: compiledCSS })
-    }
 
     html = html
       // Rewrite class names in `<head>` CSS


### PR DESCRIPTION
This PR fixes Nunjucks inheritance as discussed in #98.

Pros:

- you can now use the full power of inheritance in Nunjucks 💪
- not limited to naming your template's main block, `{% block template %}`

Cons:

- can't define `layout` in Front Matter anymore, must use `{% extends "path/to/layout.njk" %}` at the top of every template, after Front Matter
- because every template must specify the layout (or template) it `extends`, we cannot use the 'default layout' functionality anymore