### PR TITLE
PostHTML content transforms.

### DIFF
--- a/src/transformers/posthtmlContent.js
+++ b/src/transformers/posthtmlContent.js
@@ -3,11 +3,16 @@ const Tailwind = require('../generators/tailwind')
 const posthtmlContent = require('posthtml-content')
 
 module.exports = async (html, config) => {
-  html = await posthtml([
-    posthtmlContent({
-      tailwind: css => Tailwind.fromString(css, html, false, config)
-    })
-  ]).process(html).then(res => res.html)
+  let replacements = config.transformContents || {}
+  replacements.tailwind = (css) => Tailwind.fromString(css, html, false, config)
+
+  replacements = Object.keys(replacements)
+    .sort()
+    .reduce((acc, key) => ({
+      ...acc, [key]: replacements[key]
+    }), {})
+
+  html = await posthtml([posthtmlContent(replacements)]).process(html).then(res => res.html)
 
   return html
 }


### PR DESCRIPTION
This PR adds support for user-defined content transforms through [`posthtml-content`](https://github.com/posthtml/posthtml-content). 

Use this to do anything you want to content inside elements that you mark with custom attributes.

### Usage

First, add a `transformContents` object to your Maizzle config:

```js
//config.js

module.exports = {
  // ...
  transformContents: {},
}
```

Each entry in this object is made up of a `key: value` pair.

- `key` represents a custom HTML attribute name
- `value` is a function that accepts a `parameter`, and must return a string. `parameter` is the contents of the tag on which the `key` attribute was used.

#### Example

```js
//config.js

module.exports = {
  // ...
  transformContents: {
    fooreplace: str => str.replace(/foo/g, 'foo bar'),
  }
}
```

Template:

```html
<p fooreplace>Here is some foo.</p>
```

Result:

```diff
- <p fooreplace>Here is some foo.</p>
+ <p>Here is some foo bar.</p>
```

Of course, this is just a dumb example - you could pull in packages and do stuff like:

- compile CSS in some `<style>` tag with Sass or others
- minify only parts of your code
- highlight code syntax
- ...