### PR TITLE
Add error information per file

### DIFF
--- a/src/generators/output/toDisk.js
+++ b/src/generators/output/toDisk.js
@@ -49,16 +49,20 @@ module.exports = async (env, spinner) => {
     const events = templateConfig.events || []
     templateConfig.isMerged = true
 
-    html = await render(html, {
-      tailwind: {
-        compiled: css
-      },
-      maizzle: {
-        config: templateConfig
-      },
-      env: env,
-      ...events
-    })
+    try {
+      html = await render(html, {
+        tailwind: {
+          compiled: css
+        },
+        maizzle: {
+          config: templateConfig
+        },
+        env: env,
+        ...events
+      })
+    } catch (err) {
+      throw `Error building file ${file}: ${err}`
+    }
 
     const ext = templateConfig.build.destination.extension || 'html'
 


### PR DESCRIPTION
Hey!

Instead of just complaining I decided to help out and create a small PR for this.

I really need this feature because I did a couple of emails without testing any of them and now I am stumped because I do not know which one failed.

I am not 100% sure this is the only thing needed to do.

At first I tried adding the file variable to the render method but I'm guessing you wouldn't want to make the responsibility of that component to log a more "prettier" error so I put it a layer above on the toDisk.js but I still couldn't find the "single file" part of the code where this should also be applied.

Also I haven't tested this locally since I do not know how to do that.

Can you help me out on this?
