### PR TITLE
Tailwind 1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1098,14 +1098,14 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001046",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001046.tgz",
-          "integrity": "sha512-CsGjBRYWG6FvgbyGy+hBbaezpwiqIOLkxQPY4A4Ea49g1eNsnQuESB+n4QM0BKii1j80MyJ26Ir5ywTQkbRE4g=="
+          "version": "1.0.30001048",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz",
+          "integrity": "sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg=="
         },
         "electron-to-chromium": {
-          "version": "1.3.416",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.416.tgz",
-          "integrity": "sha512-fmSrpOQC1dEXzsznzAMXbhQLkpAr21WtaUfRXnIbh8kblZIaMwSL6A8u2RZHAzZliSoSOM3FzS2z/j8tVqrAAw=="
+          "version": "1.3.424",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.424.tgz",
+          "integrity": "sha512-h8apsMr1RK3OusH8iwxlJ7TZkpgWfg2HvTXZ3o1w9R/SeRKX0hEGMQmRyTWijZAloHfmfwTLaPurVqKWdFC5dw=="
         },
         "node-releases": {
           "version": "1.1.53",
@@ -1113,9 +1113,9 @@
           "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
         },
         "postcss-value-parser": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
-          "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+          "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
         }
       }
     },
@@ -2802,6 +2802,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2823,6 +2832,15 @@
         "hex-color-regex": "^1.1.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.isplainobject": "^4.0.6"
+      }
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "combined-stream": {
@@ -10991,6 +11009,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11919,13 +11952,16 @@
       }
     },
     "tailwindcss": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.3.5.tgz",
-      "integrity": "sha512-hHGShfHBj7tAQRobnsYckDySPpMDnPF4KejHYYRcZjZQvyRRnCSHi2S905icK24HrYadOq9pZKwENqg2axSviw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.4.0.tgz",
+      "integrity": "sha512-Np/VKalw2CI8EUSKNwGLFoqWIiBYVv5LpzBjQKI8XajA2SaVDj/C+YKHctmSZKR97LiiB1S81itZwtGT+BQAiQ==",
       "requires": {
+        "@fullhuman/postcss-purgecss": "^2.1.2",
         "autoprefixer": "^9.4.5",
+        "browserslist": "^4.12.0",
         "bytes": "^3.0.0",
         "chalk": "^4.0.0",
+        "color": "^3.1.2",
         "detective": "^5.2.0",
         "fs-extra": "^8.0.0",
         "lodash": "^4.17.15",
@@ -11950,6 +11986,22 @@
             "color-convert": "^2.0.1"
           }
         },
+        "browserslist": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+          "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001043",
+            "electron-to-chromium": "^1.3.413",
+            "node-releases": "^1.1.53",
+            "pkg-up": "^2.0.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001048",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz",
+          "integrity": "sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg=="
+        },
         "chalk": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
@@ -11972,6 +12024,11 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "electron-to-chromium": {
+          "version": "1.3.424",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.424.tgz",
+          "integrity": "sha512-h8apsMr1RK3OusH8iwxlJ7TZkpgWfg2HvTXZ3o1w9R/SeRKX0hEGMQmRyTWijZAloHfmfwTLaPurVqKWdFC5dw=="
+        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -11983,9 +12040,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
         "has-flag": {
           "version": "4.0.0",
@@ -12004,6 +12061,11 @@
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "node-releases": {
+          "version": "1.1.53",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+          "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
         },
         "resolve": {
           "version": "1.17.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6179,6 +6179,14 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
+    "import-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+      "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+      "requires": {
+        "import-from": "^3.0.0"
+      }
+    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -6187,6 +6195,21 @@
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      }
+    },
+    "import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        }
       }
     },
     "import-lazy": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prevent-widows": "^1.0.2",
     "query-string": "^6.12.1",
     "string-strip-html": "^4.3.22",
-    "tailwindcss": "^1.3.5"
+    "tailwindcss": "^1.4.0"
   },
   "devDependencies": {
     "ava": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fs-extra": "^9.0.0",
     "glob-promise": "^3.4.0",
     "html-crush": "^1.9.27",
+    "import-cwd": "^3.0.0",
     "juice": "^6.0.0",
     "ora": "^4.0.4",
     "postcss": "^7.0.27",

--- a/src/generators/tailwind.js
+++ b/src/generators/tailwind.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const fs = require('fs-extra')
 const postcss = require('postcss')
+const importCwd = require('import-cwd')
 const tailwind = require('tailwindcss')
 const mqpacker = require('css-mqpacker')
 const atImport = require('postcss-import')
@@ -40,8 +41,9 @@ module.exports = {
 
     const mergeLonghandPlugin = env === 'local' ? () => {} : mergeLonghand()
 
-    const tailwindConfig = isObject(config) ? getPropValue(config, 'build.tailwind.config') || {} : {}
-    const tailwindPlugin = isEmptyObject(tailwindConfig) ? tailwind() : tailwind(tailwindConfig)
+    const tailwindConfig = isObject(config) ? getPropValue(config, 'build.tailwind.config') || {} : 'tailwind.config.js'
+    const tailwindConfigObject = importCwd.silent(`./${tailwindConfig}`) || tailwindConfig
+    const tailwindPlugin = tailwind({target: 'ie11', ...tailwindConfigObject})
 
     const postcssUserPlugins = getPropValue(config, 'build.postcss.plugins') || []
 

--- a/test/test-tailwind.js
+++ b/test/test-tailwind.js
@@ -63,15 +63,15 @@ test('uses postcss plugins from the config when compiling from file', async t =>
     build: {
       postcss: {
         plugins: [
-          require('autoprefixer')({overrideBrowserslist: ['> 0.01%']})
+          require('autoprefixer')({overrideBrowserslist: ['ie >= 9']})
         ]
       }
     },
     purgeCSS: {
-      content: [{raw: '<div class="object-cover"></div>'}]
+      content: [{raw: '<div class="rotate-90"></div>'}]
     }
   }
   const css = await Tailwind.fromFile(config)
   t.not(css, undefined)
-  t.is(css, '.object-cover {\n  -o-object-fit: cover;\n     object-fit: cover\n}')
+  t.is(css, '.rotate-90 {\n  -ms-transform: rotate(90deg);\n      transform: rotate(90deg)\n}')
 })

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -12,6 +12,11 @@ const clean = html => html.replace(/[^\S\n]+$/gm, '').trim()
 
 const maizzleConfig = (options = {}) => {
   return {
+    tailwind: {
+      config: {
+        target: 'ie11'
+      }
+    },
     maizzle: {
       config: {
         env: 'node',


### PR DESCRIPTION
This PR adds support for Tailwind CSS 1.4.

## `target` 

In order to ensure email-compatible `background-color` and `color` utilities, this release uses `target: 'ie11'` by default behind the scenes. However, you are free to override it in your `tailwind.config.js`.

## CSS purging

You can use Maizzle's `purgeCSS` config options, the `purge` config key from Tailwind, or even a combination of the two. Content sources, as well as PurgeCSS options are collected by Maizzle from both places and merged into a single config object that it uses to purge unused CSS.

This will always run only once, so you don't need to worry about it running twice just because you prefer using Tailwind's config for the PurgeCSS options 👍