### PR TITLE
feat(todisk): support multiple asset paths

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -111,8 +111,12 @@ module.exports = async (env, spinner, config = {}) => {
 
   const assets = {source: '', destination: 'assets', ...getPropValue(config, 'build.assets')}
 
-  if (fs.pathExistsSync(assets.source)) {
-    await fs.copy(assets.source, `${outputDir}/${assets.destination}`)
+  if (Array.isArray(assets.source)) {
+    await asyncForEach(assets.source, async source => {
+      await fs.copy(source, `${outputDir}/${assets.destination}`).catch(error => spinner.warn(error.message))
+    })
+  } else {
+    await fs.copy(assets.source, `${outputDir}/${assets.destination}`).catch(error => spinner.warn(error.message))
   }
 
   const files = await glob(`${outputDir}/**/*.*`)

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -230,3 +230,24 @@ test('runs the `afterBuild` event', async t => {
 
   t.deepEqual(t.context.afterBuild, files)
 })
+
+test('supports multiple asset paths', async t => {
+  await Maizzle.build('production', {
+    build: {
+      fail: 'silent',
+      destination: {
+        path: t.context.folder
+      },
+      templates: {
+        root: 'test/stubs/templates'
+      },
+      assets: {
+        source: ['test/stubs/assets', 'test/stubs/plaintext'],
+        destination: 'extras'
+      }
+    }
+  })
+
+  t.true(fs.existsSync(`${t.context.folder}/extras/foo.bar`))
+  t.true(fs.existsSync(`${t.context.folder}/extras/plaintext.html`))
+})


### PR DESCRIPTION
This PR adds support for using multiple asset paths:

```js
// config.js
module.exports = {
  build: {
    assets: {
      source: ['src/assets/images', 'src/fonts'],
      destination: 'assets',
    },
    // ...
  }
}
```