### PR TITLE
fix: events in serve method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,8 @@ const self = module.exports = { // eslint-disable-line
                     maizzle: config,
                     tailwind: {
                       css: cssString
-                    }
+                    },
+                    ...config.events
                   })
                     .then(async ({html}) => {
                       await fs.outputFile(path.join(destination, file.replace(fileSource, '')), html)


### PR DESCRIPTION
This PR fixes an issue with events not running on subsequent _template_ saves when using `maizzle serve` to develop locally.

It _did_ work initially right when triggering the command, because we first use the `build()` method to compile all templates, and that correctly passes events you have defined to the `render()` method.

After that, every time you save a template, Maizzle uses the [`render()`](https://maizzle.com/docs/nodejs/) method to compile only _that_ template, resulting in very fast local development. However, when this functionality was [introduced](https://github.com/maizzle/framework/commit/7b78094219e205c802f63ab02476bc3841a73ebc#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R75-R80) in 2.3.0, I forgot about events and how they also need to be passed along to `render()`. This PR fixes that, so things work as expected in this regard.