### PR TITLE
feat(posthtml): define top-level locals in config

### DIFF
--- a/src/generators/posthtml.js
+++ b/src/generators/posthtml.js
@@ -21,7 +21,12 @@ module.exports = async (html, config) => {
   const posthtmlPlugins = getPropValue(config, 'build.posthtml.plugins') || []
 
   const expressionsOptions = getPropValue(config, 'build.posthtml.expressions') || {}
-  const expressionsPlugin = expressions({...expressionsOptions, locals: {page: config}})
+  const locals = {
+    page: config,
+    ...getPropValue(expressionsOptions, 'locals') || {},
+    ...getPropValue(config, 'locals') || {}
+  }
+  const expressionsPlugin = expressions({...expressionsOptions, locals})
 
   return posthtml([
     layouts({strict: false, ...layoutsOptions}),

--- a/src/generators/posthtml.js
+++ b/src/generators/posthtml.js
@@ -22,9 +22,9 @@ module.exports = async (html, config) => {
 
   const expressionsOptions = getPropValue(config, 'build.posthtml.expressions') || {}
   const locals = {
-    page: config,
     ...getPropValue(expressionsOptions, 'locals') || {},
-    ...getPropValue(config, 'locals') || {}
+    ...getPropValue(config, 'locals') || {},
+    page: config
   }
   const expressionsPlugin = expressions({...expressionsOptions, locals})
 

--- a/test/test-tostring.js
+++ b/test/test-tostring.js
@@ -73,3 +73,25 @@ test('runs the `afterTransformers` event', async t => {
 
   t.is(result, `<div>bar</div>`)
 })
+
+test('multiple locals', async t => {
+  const result = await renderString(`{{ page.one }}, {{ two }}, {{ three }}`, {
+    maizzle: {
+      one: 1,
+      build: {
+        posthtml: {
+          expressions: {
+            locals: {
+              two: 2
+            }
+          }
+        }
+      },
+      locals: {
+        three: 3
+      }
+    }
+  })
+
+  t.is(result, `1, 2, 3`)
+})

--- a/test/test-tostring.js
+++ b/test/test-tostring.js
@@ -95,3 +95,29 @@ test('multiple locals', async t => {
 
   t.is(result, `1, 2, 3`)
 })
+
+test('prevents overwriting page object', async t => {
+  const result = await renderString(`{{ page.one }}, {{ two }}, {{ three }}`, {
+    maizzle: {
+      one: 1,
+      build: {
+        posthtml: {
+          expressions: {
+            locals: {
+              page: {
+                two: 2
+              }
+            }
+          }
+        }
+      },
+      locals: {
+        page: {
+          three: 3
+        }
+      }
+    }
+  })
+
+  t.is(result, `1, undefined, undefined`)
+})


### PR DESCRIPTION
This PR adds support for user-defined top-level config objects.

In other words, you can define [variables](https://maizzle.com/docs/layouts/#variables) (a.k.a. `locals`) outside of the `page` object.

Simply add a `locals` object to your `config.js`:

```js
module.exports = {
  locals: {
    company: {
      name: 'Spacely Space Sprockets, Inc.'
    }
  }
}
```

You can access `company.name` directly, no need for the `page` object:

```html
<h1>{{ company.name }}</h1>
```

Alternatively, you can also create a top-level config object by configuring `posthtml-expressions` and passing in `locals` there:

```js
module.exports = {
  build: {
    posthtml: {
      expressions: {
        locals: {
          foo: 'bar'
        }
      }
    }
  }
}
```

```html
<p>'foo' is {{ foo }}</p>
```

Note: overwriting the `page` object is not possible, so if you do something like this:

```js
module.exports = {
  locals: {
    page: {
      foo: 'bar'
    }
  }
}
```

... Maizzle will overwrite that `locals.page` object, and `foo` will be `undefined`.