### PR TITLE
fix: use posthtml options in components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "posthtml-extra-attributes": "^1.0.0",
         "posthtml-fetch": "^1.2.0",
         "posthtml-markdownit": "^1.2.2",
-        "posthtml-modules": "^0.7.3",
+        "posthtml-modules": "^0.7.4",
         "posthtml-mso": "^1.0.2",
         "posthtml-postcss-merge-longhand": "^1.0.2",
         "posthtml-remove-attributes": "^1.0.0",
@@ -10140,12 +10140,12 @@
       "integrity": "sha1-RRJT3o5YRKNI6WOtXt13aesSlRM="
     },
     "node_modules/posthtml-modules": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/posthtml-modules/-/posthtml-modules-0.7.3.tgz",
-      "integrity": "sha512-KkOD7kpAwxZkHbFpjzHHuJ/u9ut3zKKLzooPosHz27vE0hGeEIa9/wIdMuZ+NZ1I/D6zcPgkS0aE1NhFmlLTmw==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/posthtml-modules/-/posthtml-modules-0.7.4.tgz",
+      "integrity": "sha512-gKAk6XZpiyz7591KYABP17tmfdckcGaynS4mTKZ2XoVSUK5UaNbYea9RYcn7YpumYw11oz8KWw7711Z2CUZ8NQ==",
       "dependencies": {
         "is-json": "^2.0.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "posthtml-expressions": "^1.7.1",
         "posthtml-match-helper": "^1.0.1",
         "posthtml-render": "^1.4.0"
@@ -22277,12 +22277,12 @@
       "integrity": "sha1-RRJT3o5YRKNI6WOtXt13aesSlRM="
     },
     "posthtml-modules": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/posthtml-modules/-/posthtml-modules-0.7.3.tgz",
-      "integrity": "sha512-KkOD7kpAwxZkHbFpjzHHuJ/u9ut3zKKLzooPosHz27vE0hGeEIa9/wIdMuZ+NZ1I/D6zcPgkS0aE1NhFmlLTmw==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/posthtml-modules/-/posthtml-modules-0.7.4.tgz",
+      "integrity": "sha512-gKAk6XZpiyz7591KYABP17tmfdckcGaynS4mTKZ2XoVSUK5UaNbYea9RYcn7YpumYw11oz8KWw7711Z2CUZ8NQ==",
       "requires": {
         "is-json": "^2.0.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "posthtml-expressions": "^1.7.1",
         "posthtml-match-helper": "^1.0.1",
         "posthtml-render": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "posthtml-extra-attributes": "^1.0.0",
     "posthtml-fetch": "^1.2.0",
     "posthtml-markdownit": "^1.2.2",
-    "posthtml-modules": "^0.7.3",
+    "posthtml-modules": "^0.7.4",
     "posthtml-mso": "^1.0.2",
     "posthtml-postcss-merge-longhand": "^1.0.2",
     "posthtml-remove-attributes": "^1.0.0",

--- a/src/generators/posthtml.js
+++ b/src/generators/posthtml.js
@@ -32,6 +32,7 @@ module.exports = async (html, config) => {
     layouts({strict: false, ...layoutsOptions}),
     fetchPlugin,
     modules({
+      parser: posthtmlOptions,
       from: modulesFrom,
       root: modulesRoot,
       tag: 'component',


### PR DESCRIPTION
This PR fixes an issue with PostHTML options not being used when rendering Components.

Fixes #417.