### PR TITLE
fix: destination extension

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -69,6 +69,12 @@ module.exports = async (env, spinner, config) => {
               const destination = config.permalink || file
               const plaintextConfig = get(config, 'plaintext')
 
+              /**
+               * Generate plaintext
+               *
+               * We do this first so that we can remove the <plaintext>
+               * tags from the markup before outputting the file.
+               */
               if ((typeof plaintextConfig === 'boolean' && plaintextConfig) || !isEmpty(plaintextConfig)) {
                 await Plaintext
                   .generate(html, destination, config)
@@ -77,14 +83,15 @@ module.exports = async (env, spinner, config) => {
 
               html = removePlaintextTags(html, config)
 
+              /**
+               * Output file
+               */
+              const parts = path.parse(destination)
+              const extension = get(templateConfig, 'destination.extension', 'html')
+
               await fs.outputFile(destination, html)
                 .then(async () => {
-                  const extension = get(templateConfig, 'destination.extension', 'html')
-
-                  if (extension !== 'html') {
-                    const parts = path.parse(destination)
-                    await fs.move(destination, `${parts.dir}/${parts.name}.${extension}`)
-                  }
+                  await fs.rename(destination, `${parts.dir}/${parts.name}.${extension}`)
 
                   files.push(file)
                   parsed.push(file)

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -89,7 +89,7 @@ test('outputs files at the correct location if multiple template sources are use
   t.is(files.length, 4)
 })
 
-test('processes all files in the `filetypes` option', async t => {
+test('copies all files in the `filetypes` option to destination', async t => {
   const {files} = await Maizzle.build('production', {
     build: {
       fail: 'silent',
@@ -109,7 +109,7 @@ test('processes all files in the `filetypes` option', async t => {
   })
 
   t.true(fs.pathExistsSync(t.context.folder))
-  t.is(files.length, 3)
+  t.is(files.length, 4)
 })
 
 test('outputs files with the correct extension', async t => {


### PR DESCRIPTION
This PR fixes an issue with files not being output with the correct extension, so you can use non-HTML files when developing and have them output with the `.html` extension so you can preview them in the browser.

Fixes #485 