### PR TITLE
fix: output paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,20 +65,21 @@ const self = module.exports = { // eslint-disable-line
 
             file = file.replace(/\\/g, '/')
 
-            const parts = path.parse(file)
-            const destination = get(config, 'build.currentTemplates.destination.path')
+            const destination = get(config, 'build.currentTemplates.destination.path', 'build_local')
             const extension = get(config, 'build.currentTemplates.destination.extension', 'html')
-            const finalDestination = path.join(destination, `${parts.name}.${extension}`)
+            const fileSource = get(config, 'build.currentTemplates.source')
+            const parts = path.parse(path.join(destination, file.replace(fileSource, '')))
+            const finalDestination = path.join(parts.dir, `${parts.name}.${extension}`)
 
             if (config.events && typeof config.events.beforeCreate === 'function') {
               await config.events.beforeCreate(config)
             }
 
             /**
-             * Tailwind compiler
+             * Tailwind CSS compiler
              *
-             * Use the JIT engine if user enabled it
-             * Fall back to the classic, Always-On-Time engine
+             * Use the Just-In-Time engine if the user enabled it
+             * Fall back to the classic Always-On-Time engine
              */
             let mode = 'aot'
 
@@ -101,7 +102,7 @@ const self = module.exports = { // eslint-disable-line
 
             self
               .render(await fs.readFile(file, 'utf8'), renderOptions)
-              .then(({html}) => fs.outputFile(finalDestination, html))
+              .then(({html, config}) => fs.outputFile(config.permalink || finalDestination, html))
               .then(() => {
                 bs.reload()
                 spinner.succeed(`Done in ${Date.now() - start} ms.`)

--- a/xo.config.js
+++ b/xo.config.js
@@ -5,6 +5,7 @@ module.exports = {
     complexity: 0,
     'no-lonely-if': 0,
     'unicorn/no-reduce': 0,
+    'operator-linebreak': 0,
     'max-nested-callbacks': 0,
     'unicorn/prefer-ternary': 0,
     'unicorn/string-content': 0,


### PR DESCRIPTION
This PR fixes some issues with destination paths.

- fixes #497 
- fixed an issue with template `permalink ` in Front Matter not being respected when using `maizzle build` (with no `env`)
- fixed an issue with file types not being correctly excluded
- fixed an issue where the original file was not cleaned up from the destination path when using non-HTML source templates
