### PR TITLE
feat: autoload tailwind.css if it exists

### DIFF
--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -43,7 +43,7 @@ module.exports = {
     // Merge user's Tailwind plugins with our default ones
     config.plugins.push(require('tailwindcss-box-shadow'))
 
-    const userFilePath = get(maizzleConfig, 'build.tailwind.css')
+    const userFilePath = get(maizzleConfig, 'build.tailwind.css', path.join(process.cwd(), 'src/css/tailwind.css'))
 
     css = await fs.pathExists(userFilePath).then(async exists => {
       if (exists) {


### PR DESCRIPTION
Maizzle will try to automatically load `src/css/tailwind.css` from your current working directory, so you don't need to define the path to it in your `config.js` anymore:

```diff
module.exports = {
  build: {
-    tailwind: {
-      css: 'src/css/tailwind.css',
-    },
  },
}
```

If the file does not exist, Maizzle will compile Tailwind using `@tailwind components; @tailwind utilities;` using your `tailwind.config.js`.