### PR TITLE
feat: generate plaintext on a template source basis

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -72,8 +72,6 @@ module.exports = async (env, spinner, config) => {
           })
             .then(async ({html, config}) => {
               const destination = config.permalink || file
-              const plaintextConfig = get(config, 'plaintext')
-              const plaintextDestination = get(plaintextConfig, 'destination', config.permalink || file)
 
               /**
                * Generate plaintext
@@ -81,6 +79,11 @@ module.exports = async (env, spinner, config) => {
                * We do this first so that we can remove the <plaintext>
                * tags from the markup before outputting the file.
                */
+
+              // Make this a breaking change in 4.0, get only from `templateConfig`
+              const plaintextConfig = get(templateConfig, 'plaintext', get(config, 'plaintext'))
+              const plaintextDestination = get(plaintextConfig, 'destination', config.permalink || file)
+
               if ((typeof plaintextConfig === 'boolean' && plaintextConfig) || !isEmpty(plaintextConfig)) {
                 await Plaintext
                   .generate(html, plaintextDestination, merge(config, {filepath: file}))

--- a/src/generators/plaintext.js
+++ b/src/generators/plaintext.js
@@ -3,7 +3,7 @@ const {get} = require('lodash')
 const {stripHtml} = require('string-strip-html')
 
 module.exports.generate = async (html, destination, config) => {
-  const options = get(config, 'plaintext', {})
+  const options = get(config, 'build.currentTemplates.plaintext', get(config, 'plaintext', {}))
   const configDestinationPath = get(options, 'destination.path')
   const extension = get(options, 'destination.extension', 'txt')
   const plaintext = stripHtml(html, {


### PR DESCRIPTION
This PR adds support for generating plaintext files only for those template sources that opt in. Now, when using multiple template sources, Maizzle will first check if the currently-being-built templates source has enabled plaintext.

Basically, you can now do this:

```js
// config.js
module.exports = {
  build: {
    templates: [
      {
        source: 'src/templates',
        destination: {
          path: 'build-1',
        },
        plaintext: true // build-1 folder only: output plaintext files next to the HTML counterparts
      },
      {
        source: 'src/templates',
        destination: {
          path: 'build-2',
        },
        // build-2 folder only: output plaintext files in the `plaintext` subdirectory, with custom extension
        plaintext: {
          destination: {
            path: 'build-2/plaintext',
            extension: 'rtxt'
          }
        },
      },
      // plaintext won't be generated in the `build-3` directory, because we didn't enable it
      {
        source: 'src/templates',
        destination: {
          path: 'build-3',
        }
      },
    ]
  }
}
```

### Generating plaintext versions of all templates

Of course, you can still define a top-level `plaintext` config key.

This will generate plaintext versions for all of your templates:

```js
module.exports = {
  templates: {
    source: 'src/templates',
    destination: {
      path: 'build_local',
    },
  },
  plaintext: true,
}
```

You may also define the destination and file extension to use, when enabling plaintext for all templates:

```js
module.exports = {
  templates: {
    source: 'src/templates',
    destination: {
      path: 'build_local',
    },
  },
  plaintext: {
    destination: {
      path: 'build_local/plaintext',
      extension: 'rtxt'
    }
  },
}
```

### Permalinks

`permalink` set in your template's Front Matter will work the same, take precedence over everything and outputting the plaintext file at the exact file path that you define.