### PR TITLE
fix: missing frontmatter breaks posthtml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3532,9 +3532,9 @@
       ]
     },
     "node_modules/domhandler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -3546,9 +3546,9 @@
       }
     },
     "node_modules/domutils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -11087,14 +11087,43 @@
       }
     },
     "node_modules/posthtml-parser": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.0.tgz",
-      "integrity": "sha512-UmQVou44koVf8ZHBGstAIch8cD2lnPALq9KvAi34ZRdNGp9bRkFl5K5QVx/F+PUv1ghxhYIBRxQO7H6daIP/Hw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.1.tgz",
+      "integrity": "sha512-i7w2QEHqiGtsvNNPty0Mt/+ERch7wkgnFh3+JnBI2VgDbGlBqKW9eDVd3ENUhE1ujGFe3e3E/odf7eKhvLUyDg==",
       "dependencies": {
-        "htmlparser2": "^6.0.0"
+        "htmlparser2": "^7.1.1"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/posthtml-parser/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/posthtml-parser/node_modules/htmlparser2": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.1.2.tgz",
+      "integrity": "sha512-d6cqsbJba2nRdg8WW2okyD4ceonFHn9jLFxhwlNcLhQWcFPdxXeJulgOLjLKtAK9T6ahd+GQNZwG9fjmGW7lyg==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
       }
     },
     "node_modules/posthtml-postcss-merge-longhand": {
@@ -18051,17 +18080,17 @@
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
     },
     "domhandler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-      "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
       "requires": {
         "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -23698,11 +23727,29 @@
       }
     },
     "posthtml-parser": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.0.tgz",
-      "integrity": "sha512-UmQVou44koVf8ZHBGstAIch8cD2lnPALq9KvAi34ZRdNGp9bRkFl5K5QVx/F+PUv1ghxhYIBRxQO7H6daIP/Hw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.1.tgz",
+      "integrity": "sha512-i7w2QEHqiGtsvNNPty0Mt/+ERch7wkgnFh3+JnBI2VgDbGlBqKW9eDVd3ENUhE1ujGFe3e3E/odf7eKhvLUyDg==",
       "requires": {
-        "htmlparser2": "^6.0.0"
+        "htmlparser2": "^7.1.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+        },
+        "htmlparser2": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.1.2.tgz",
+          "integrity": "sha512-d6cqsbJba2nRdg8WW2okyD4ceonFHn9jLFxhwlNcLhQWcFPdxXeJulgOLjLKtAK9T6ahd+GQNZwG9fjmGW7lyg==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        }
       }
     },
     "posthtml-postcss-merge-longhand": {

--- a/src/generators/output/to-string.js
+++ b/src/generators/output/to-string.js
@@ -21,7 +21,11 @@ module.exports = async (html, options) => {
   const tailwindConfig = get(options, 'tailwind.config', {})
   const cssString = get(options, 'tailwind.css', '@tailwind components; @tailwind utilities;')
 
-  const frontmatter = await posthtml(fm(html).frontmatter, config)
+  let {frontmatter} = fm(html)
+
+  if (frontmatter) {
+    frontmatter = await posthtml(frontmatter, config)
+  }
 
   html = `---\n${frontmatter}\n---\n\n${fm(html).body}`
 

--- a/test/fixtures/basic.html
+++ b/test/fixtures/basic.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <title>test></title>
+  </head>
+  <body>
+    <div>test</div>
+  </body>
+</html>

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -414,5 +414,5 @@ test('local server does not compile unwanted file types', async t => {
 test('throws if it cannot spin up local development server', async t => {
   await t.throwsAsync(async () => {
     await Maizzle.serve('local', {})
-  }, {instanceOf: TypeError, message: `Cannot read property 'source' of undefined`})
+  }, {instanceOf: TypeError})
 })

--- a/test/test-tostring.js
+++ b/test/test-tostring.js
@@ -10,10 +10,11 @@ const expected = file => readFileSync(path.join(__dirname, 'expected', `${file}.
 const renderString = (string, options = {}) => Maizzle.render(string, options).then(({html}) => html)
 
 test('compiles HTML string if no options are passed', async t => {
-  let html = await renderString('<div>test</div>')
-  html = html.replace(/[^\S\r\n]+$/gm, '').trim()
+  const source = fixture('basic')
 
-  t.is(html, '<div>test</div>')
+  const html = await renderString(source)
+
+  t.is(html, source)
 })
 
 test('inheritance', async t => {


### PR DESCRIPTION
This PR fixes an issue with the build breaking if you didn't have front matter added to your HTML.

That can happen if you just have something like this, that doesn't even extend a layout:

```html
<!doctype html>
<html>
  <head>
    <title>test></title>
  </head>
  <body>
    <div>test</div>
  </body>
</html>
```

... the build will fail because `posthtml` will receive `undefined` when we try to parse expressions inside a template's front matter:

https://github.com/maizzle/framework/blob/17c9c18baa9559f3becff568be80b4c4bd9d4e00/src/generators/output/to-string.js#L24

Using the HTML in the example above, `fm(html).frontmatter` will be `undefined`, which will cause `Tokenizer.parse` in `htmlparser2` to throw a `TypeError`:

```sh
TypeError {
  message: 'Cannot read property \'length\' of undefined',
}
```