### PR TITLE
refactor: tailwindcss content sources

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,11 +3,7 @@
 
 name: Node.js CI
 
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,7 +3,10 @@
 
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build:

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -30,13 +30,23 @@ module.exports = {
       }
     }
 
+    // Include all `build.templates.source` paths when scanning for selectors to preserve
+    const buildTemplates = get(maizzleConfig, 'build.templates')
+    const templateObjects = Array.isArray(buildTemplates) ? buildTemplates : [buildTemplates]
+    const templateSources = templateObjects.map(template => {
+      const source = get(template, 'source')
+
+      return `./${source}/**/*.*`
+    })
+
     // Merge user's Tailwind config on top of a 'base' config
     const config = merge({
       important: true,
       content: {
         files: [
-          'src/**/*.*',
-          {raw: html}
+          './src/**/*.*',
+          ...templateSources,
+          {raw: html, extension: 'html'}
         ]
       },
       corePlugins: {
@@ -55,28 +65,6 @@ module.exports = {
       },
       plugins: []
     }, userConfig())
-
-    // Add back the `{raw: html}` option if user provided own config
-    if (Array.isArray(config.content)) {
-      config.content = {
-        files: [
-          ...config.content,
-          'src/**/*.*',
-          {raw: html}
-        ]
-      }
-    }
-
-    // Include all `build.templates.source` paths when scanning for selectors to preserve
-    const buildTemplates = get(maizzleConfig, 'build.templates')
-    const templateObjects = Array.isArray(buildTemplates) ? buildTemplates : [buildTemplates]
-    const templateSources = templateObjects.map(template => {
-      const source = get(template, 'source')
-
-      return `${source}/**/*.*`
-    })
-
-    config.content.files.push(...templateSources)
 
     // Merge user's Tailwind plugins with our default ones
     config.plugins.push(require('tailwindcss-box-shadow'))

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -85,18 +85,14 @@ module.exports = {
     config.plugins.push(require('tailwindcss-box-shadow'))
 
     const userFilePath = get(maizzleConfig, 'build.tailwind.css', path.join(process.cwd(), 'src/css/tailwind.css'))
+    const userFileExists = await fs.pathExists(userFilePath)
 
-    css = await fs.pathExists(userFilePath).then(async exists => {
-      if (exists) {
-        const userFileCSS = await fs.readFile(path.resolve(userFilePath), 'utf8')
-        return userFileCSS
-      }
-
-      return css
-    })
+    if (userFileExists) {
+      css = await fs.readFile(path.resolve(userFilePath), 'utf8')
+    }
 
     return postcss([
-      postcssImport({path: userFilePath ? path.dirname(userFilePath) : []}),
+      postcssImport({path: path.dirname(userFilePath)}),
       postcssNested(),
       tailwindcss(config),
       maizzleConfig.env === 'local' ? () => {} : mergeLonghand(),

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -30,22 +30,12 @@ module.exports = {
       }
     }
 
-    // Include all `build.templates.source` paths when scanning for selectors to preserve
-    const buildTemplates = get(maizzleConfig, 'build.templates')
-    const templateObjects = Array.isArray(buildTemplates) ? buildTemplates : [buildTemplates]
-    const templateSources = templateObjects.map(template => {
-      const source = get(template, 'source')
-
-      return `./${source}/**/*.*`
-    })
-
     // Merge user's Tailwind config on top of a 'base' config
     const config = merge({
       important: true,
       content: {
         files: [
           './src/**/*.*',
-          ...templateSources,
           {raw: html, extension: 'html'}
         ]
       },
@@ -65,6 +55,31 @@ module.exports = {
       },
       plugins: []
     }, userConfig())
+
+    // Add back the `{raw: html}` option if user provided own config
+    if (Array.isArray(config.content)) {
+      config.content = {
+        files: [
+          ...config.content,
+          './src/**/*.*',
+          {raw: html, extension: 'html'}
+        ]
+      }
+    }
+
+    // Include all `build.templates.source` paths when scanning for selectors to preserve
+    const buildTemplates = get(maizzleConfig, 'build.templates')
+
+    if (buildTemplates) {
+      const templateObjects = Array.isArray(buildTemplates) ? buildTemplates : [buildTemplates]
+      const templateSources = templateObjects.map(template => {
+        const source = get(template, 'source')
+
+        return `${source}/**/*.*`
+      })
+
+      config.content.files.push(...templateSources)
+    }
 
     // Merge user's Tailwind plugins with our default ones
     config.plugins.push(require('tailwindcss-box-shadow'))

--- a/test/stubs/tailwind/preserve.html
+++ b/test/stubs/tailwind/preserve.html
@@ -1,0 +1,1 @@
+<div class="hidden"></div>

--- a/test/test-tailwind.js
+++ b/test/test-tailwind.js
@@ -2,7 +2,12 @@ const test = require('ava')
 const Tailwind = require('../src/generators/tailwindcss')
 
 test('uses Tailwind defaults if no config specified', async t => {
-  const css = await Tailwind.compile('@tailwind utilities', '<p class="xl:z-0"></p>', {}, {env: 'production'})
+  const css = await Tailwind.compile(
+    '@tailwind utilities;',
+    '<p class="xl:z-0"></p>',
+    {},
+    {env: 'production'}
+  )
 
   t.not(css, undefined)
   t.true(css.includes('.xl\\:z-0'))
@@ -27,7 +32,7 @@ test('uses CSS file provided in environment config', async t => {
 
 test('works with custom `content` sources', async t => {
   const css = await Tailwind.compile(
-    '@tailwind utilities',
+    '@tailwind utilities;',
     '<div class="hidden"></div>',
     {
       content: ['./test/stubs/tailwind/*.*']
@@ -39,7 +44,7 @@ test('works with custom `content` sources', async t => {
 
 test('works with custom `files` sources', async t => {
   const css = await Tailwind.compile(
-    '@tailwind utilities',
+    '@tailwind utilities;',
     '<div></div>',
     {
       content: {
@@ -53,7 +58,7 @@ test('works with custom `files` sources', async t => {
 
 test('uses maizzle template paths when purging', async t => {
   const css = await Tailwind.compile(
-    '@tailwind utilities',
+    '@tailwind utilities;',
     '<div></div>',
     {},
     {

--- a/test/test-tailwind.js
+++ b/test/test-tailwind.js
@@ -30,7 +30,7 @@ test('works with custom `content` sources', async t => {
     '@tailwind utilities',
     '<div class="hidden"></div>',
     {
-      content: ['test/stubs/tailwind/*.*']
+      content: ['./test/stubs/tailwind/*.*']
     }
   )
 
@@ -43,7 +43,24 @@ test('works with custom `files` sources', async t => {
     '<div></div>',
     {
       content: {
-        files: ['test/stubs/tailwind/*.*']
+        files: ['./test/stubs/tailwind/*.*']
+      }
+    }
+  )
+
+  t.true(css.includes('.hidden'))
+})
+
+test('uses maizzle template paths when purging', async t => {
+  const css = await Tailwind.compile(
+    '@tailwind utilities',
+    '<div></div>',
+    {},
+    {
+      build: {
+        templates: {
+          source: './test/stubs/tailwind'
+        }
       }
     }
   )

--- a/test/test-tailwind.js
+++ b/test/test-tailwind.js
@@ -25,17 +25,30 @@ test('uses CSS file provided in environment config', async t => {
   t.true(css.includes('.foo'))
 })
 
-test('uses options from the user\'s tailwind config', async t => {
-  const css = await Tailwind.compile('@tailwind utilities', '<div class="z-0"></div>', {safelist: ['z-10']}, {})
+test('works with custom `content` sources', async t => {
+  const css = await Tailwind.compile(
+    '@tailwind utilities',
+    '<div class="hidden"></div>',
+    {
+      content: ['test/stubs/tailwind/*.*']
+    }
+  )
 
-  t.true(css.includes('.z-0'))
-  t.true(css.includes('.z-10'))
+  t.true(css.includes('.hidden'))
 })
 
-test('works with user\'s custom content sources', async t => {
-  const css = await Tailwind.compile('@tailwind utilities', '<div class="z-0"></div>', {content: ['src/**/*.js']}, {})
+test('works with custom `files` sources', async t => {
+  const css = await Tailwind.compile(
+    '@tailwind utilities',
+    '<div></div>',
+    {
+      content: {
+        files: ['test/stubs/tailwind/*.*']
+      }
+    }
+  )
 
-  t.true(css.includes('.z-0'))
+  t.true(css.includes('.hidden'))
 })
 
 test('uses custom postcss plugins from the maizzle config', async t => {


### PR DESCRIPTION
This PR refactors the way we handle content sources:

- use paths as recommended in the Tailwind CSS docs
- add back template source paths only when they're defined (i.e. when using the `render` method they'd be `undefined`)
- update tests