### PR TITLE
refactor: use plaintext config only from template config

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -81,7 +81,7 @@ module.exports = async (env, spinner, config) => {
                */
 
               // Make this a breaking change in 4.0, get only from `templateConfig`
-              const plaintextConfig = get(templateConfig, 'plaintext', get(config, 'plaintext'))
+              const plaintextConfig = get(templateConfig, 'plaintext')
               const plaintextDestination = get(plaintextConfig, 'destination', config.permalink || file)
 
               if ((typeof plaintextConfig === 'boolean' && plaintextConfig) || !isEmpty(plaintextConfig)) {

--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -80,7 +80,6 @@ module.exports = async (env, spinner, config) => {
                * tags from the markup before outputting the file.
                */
 
-              // Make this a breaking change in 4.0, get only from `templateConfig`
               const plaintextConfig = get(templateConfig, 'plaintext')
               const plaintextDestination = get(plaintextConfig, 'destination', config.permalink || file)
 

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -142,15 +142,15 @@ test('outputs plaintext files', async t => {
         source: 'test/stubs/plaintext',
         destination: {
           path: t.context.folder
-        }
+        },
+        plaintext: true
       },
       tailwind: {
         config: {
           purge: false
         }
       }
-    },
-    plaintext: true
+    }
   })
 
   const plaintext = files.filter(file => file.includes('.txt'))
@@ -171,17 +171,17 @@ test('outputs plaintext files (custom path)', async t => {
         source: 'test/stubs/plaintext',
         destination: {
           path: t.context.folder
+        },
+        plaintext: {
+          destination: {
+            path: `${t.context.folder}/nested/plain.text`
+          }
         }
       },
       tailwind: {
         config: {
           purge: false
         }
-      }
-    },
-    plaintext: {
-      destination: {
-        path: `${t.context.folder}/nested/plain.text`
       }
     }
   })


### PR DESCRIPTION
BREAKING: this PR drops support for specifying `plaintext` as a top-level Maizzle config.

In order to generate plaintext for a template, you must now either:

### 1. Define it in the config object for the templates source

```diff
build: {
  templates: {
    source: 'src/templates',
    destination: {
      path: t.context.folder,
    },
+    plaintext: true,
  },
},
- plaintext: true,
```

### 2. Define it in YAML front matter at the top of your template

```html
---
plaintext: true
---

<extends src="src/layouts/main.html">
	<block name="template">
		...
	</block>
</extends>
```
