### PR TITLE
refactor template source paths

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -37,124 +37,150 @@ module.exports = async (env, spinner, config) => {
 
     await fs.remove(outputDir)
 
-    const source = typeof templateConfig.source === 'function' ? templateConfig.source() : templateConfig.source
+    /**
+     * Get all files in the template config's source directory
+     * Supports `source` defined as:
+     * - string
+     * - array of strings
+     * - function that returns either of the above
+     *
+     *  */
+    const templateSource = []
 
-    await fs
-      .copy(source, outputDir)
-      .then(async () => {
-        const extensions = Array.isArray(templateConfig.filetypes)
-          ? templateConfig.filetypes.join('|')
-          : templateConfig.filetypes || get(templateConfig, 'filetypes', 'html')
+    if (typeof templateConfig.source === 'function') {
+      const sources = templateConfig.source()
+      if (Array.isArray(sources)) {
+        templateSource.push(...sources)
+      } else {
+        templateSource.push(sources)
+      }
+    } else {
+      if (Array.isArray(templateConfig.source)) {
+        templateSource.push(...templateConfig.source)
+      } else {
+        templateSource.push(templateConfig.source)
+      }
+    }
 
-        const templates = await glob(`${outputDir}/**/*.+(${extensions})`)
+    // Parse each template source
+    await asyncForEach(templateSource, async source => {
+      await fs
+        .copy(source, outputDir)
+        .then(async () => {
+          const extensions = Array.isArray(templateConfig.filetypes)
+            ? templateConfig.filetypes.join('|')
+            : templateConfig.filetypes || get(templateConfig, 'filetypes', 'html')
 
-        if (templates.length === 0) {
-          spinner.warn(`Error: no files with the .${extensions} extension found in ${templateConfig.source}`)
-          return
-        }
+          const templates = await glob(`${outputDir}/**/*.+(${extensions})`)
 
-        // Store template config currently being processed
-        config.build.currentTemplates = templateConfig
+          if (templates.length === 0) {
+            spinner.warn(`Error: no files with the .${extensions} extension found in ${templateConfig.source}`)
+            return
+          }
 
-        if (config.events && typeof config.events.beforeCreate === 'function') {
-          await config.events.beforeCreate(config)
-        }
+          // Store template config currently being processed
+          config.build.currentTemplates = templateConfig
 
-        await asyncForEach(templates, async file => {
-          const html = await fs.readFile(file, 'utf8')
+          if (config.events && typeof config.events.beforeCreate === 'function') {
+            await config.events.beforeCreate(config)
+          }
 
-          await render(html, {
-            maizzle: {
-              ...config,
-              env
-            },
-            tailwind: {
-              compiled: css
-            },
-            ...config.events
-          })
-            .then(async ({html, config}) => {
-              const destination = config.permalink || file
+          await asyncForEach(templates, async file => {
+            const html = await fs.readFile(file, 'utf8')
 
-              /**
-               * Generate plaintext
-               *
-               * We do this first so that we can remove the <plaintext>
-               * tags from the markup before outputting the file.
-               */
-
-              const plaintextConfig = get(templateConfig, 'plaintext')
-              const plaintextDestination = get(plaintextConfig, 'destination', config.permalink || file)
-
-              if ((typeof plaintextConfig === 'boolean' && plaintextConfig) || !isEmpty(plaintextConfig)) {
-                await Plaintext
-                  .generate(html, plaintextDestination, merge(config, {filepath: file}))
-                  .then(({plaintext, destination}) => fs.outputFile(destination, plaintext))
-              }
-
-              html = removePlaintextTags(html, config)
-
-              /**
-               * Output file
-               */
-              const parts = path.parse(destination)
-              const extension = get(templateConfig, 'destination.extension', 'html')
-              const finalDestination = `${parts.dir}/${parts.name}.${extension}`
-
-              await fs.outputFile(finalDestination, html)
-                .then(async () => {
-                  /**
-                   * Remove original file if its path is different
-                   * from the final destination path.
-                   *
-                   * This ensures non-HTML files do not pollute
-                   * the build destination folder.
-                   */
-                  if (finalDestination !== file) {
-                    await fs.remove(file)
-                  }
-
-                  // Keep track of handled files
-                  files.push(file)
-                  parsed.push(file)
-                })
+            await render(html, {
+              maizzle: {
+                ...config,
+                env
+              },
+              tailwind: {
+                compiled: css
+              },
+              ...config.events
             })
-            .catch(error => {
-              switch (config.build.fail) {
-                case 'silent':
-                  spinner.warn(`Failed to compile template: ${path.basename(file)}`)
-                  break
-                case 'verbose':
-                  spinner.warn(`Failed to compile template: ${path.basename(file)}`)
-                  console.error(error)
-                  break
-                default:
-                  spinner.fail(`Failed to compile template: ${path.basename(file)}`)
-                  throw error
+              .then(async ({html, config}) => {
+                const destination = config.permalink || file
+
+                /**
+                 * Generate plaintext
+                 *
+                 * We do this first so that we can remove the <plaintext>
+                 * tags from the markup before outputting the file.
+                 */
+
+                const plaintextConfig = get(templateConfig, 'plaintext')
+                const plaintextDestination = get(plaintextConfig, 'destination', config.permalink || file)
+
+                if ((typeof plaintextConfig === 'boolean' && plaintextConfig) || !isEmpty(plaintextConfig)) {
+                  await Plaintext
+                    .generate(html, plaintextDestination, merge(config, {filepath: file}))
+                    .then(({plaintext, destination}) => fs.outputFile(destination, plaintext))
+                }
+
+                html = removePlaintextTags(html, config)
+
+                /**
+                 * Output file
+                 */
+                const parts = path.parse(destination)
+                const extension = get(templateConfig, 'destination.extension', 'html')
+                const finalDestination = `${parts.dir}/${parts.name}.${extension}`
+
+                await fs.outputFile(finalDestination, html)
+                  .then(async () => {
+                    /**
+                     * Remove original file if its path is different
+                     * from the final destination path.
+                     *
+                     * This ensures non-HTML files do not pollute
+                     * the build destination folder.
+                     */
+                    if (finalDestination !== file) {
+                      await fs.remove(file)
+                    }
+
+                    // Keep track of handled files
+                    files.push(file)
+                    parsed.push(file)
+                  })
+              })
+              .catch(error => {
+                switch (config.build.fail) {
+                  case 'silent':
+                    spinner.warn(`Failed to compile template: ${path.basename(file)}`)
+                    break
+                  case 'verbose':
+                    spinner.warn(`Failed to compile template: ${path.basename(file)}`)
+                    console.error(error)
+                    break
+                  default:
+                    spinner.fail(`Failed to compile template: ${path.basename(file)}`)
+                    throw error
+                }
+              })
+          })
+
+          const assets = {source: '', destination: 'assets', ...get(templateConfig, 'assets')}
+
+          if (Array.isArray(assets.source)) {
+            await asyncForEach(assets.source, async source => {
+              if (fs.existsSync(source)) {
+                await fs.copy(source, path.join(templateConfig.destination.path, assets.destination)).catch(error => spinner.warn(error.message))
               }
+            })
+          } else {
+            if (fs.existsSync(assets.source)) {
+              await fs.copy(assets.source, path.join(templateConfig.destination.path, assets.destination)).catch(error => spinner.warn(error.message))
+            }
+          }
+
+          await glob(path.join(templateConfig.destination.path, '/**/*.*'))
+            .then(contents => {
+              files = [...new Set([...files, ...contents])]
             })
         })
-
-        const assets = {source: '', destination: 'assets', ...get(templateConfig, 'assets')}
-
-        if (Array.isArray(assets.source)) {
-          await asyncForEach(assets.source, async source => {
-            if (fs.existsSync(source)) {
-              await fs.copy(source, path.join(templateConfig.destination.path, assets.destination)).catch(error => spinner.warn(error.message))
-            }
-          })
-        } else {
-          if (fs.existsSync(assets.source)) {
-            await fs.copy(assets.source, path.join(templateConfig.destination.path, assets.destination)).catch(error => spinner.warn(error.message))
-          }
-        }
-
-        await glob(path.join(templateConfig.destination.path, '/**/*.*'))
-          .then(contents => {
-            files = [...new Set([...files, ...contents])]
-          })
-      })
-      .catch(error => spinner.warn(error.message))
+        .catch(error => spinner.warn(error.message))
+    })
   })
 
   if (config.events && typeof config.events.afterBuild === 'function') {

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -43,7 +43,7 @@ test('skips if no templates found', async t => {
 })
 
 test('outputs files at the correct location', async t => {
-  const {files} = await Maizzle.build('production', {
+  const {files: string} = await Maizzle.build('production', {
     build: {
       fail: 'silent',
       templates: {
@@ -51,17 +51,25 @@ test('outputs files at the correct location', async t => {
         destination: {
           path: t.context.folder
         }
-      },
-      tailwind: {
-        config: {
-          purge: false
+      }
+    }
+  })
+
+  const {files: array} = await Maizzle.build('production', {
+    build: {
+      fail: 'silent',
+      templates: {
+        source: ['test/stubs/templates'],
+        destination: {
+          path: t.context.folder
         }
       }
     }
   })
 
   t.true(fs.pathExistsSync(t.context.folder))
-  t.is(files.length, 3)
+  t.is(string.length, 3)
+  t.is(array.length, 3)
 })
 
 test('outputs files at the correct location if multiple template sources are used', async t => {
@@ -417,12 +425,29 @@ test('throws if it cannot spin up local development server', async t => {
   }, {instanceOf: TypeError})
 })
 
-test('works with templates.source defined as function', async t => {
+test('works with templates.source defined as function (string paths)', async t => {
   const {files} = await Maizzle.build('production', {
     build: {
       fail: 'silent',
       templates: {
         source: () => 'test/stubs/templates',
+        destination: {
+          path: t.context.folder
+        }
+      }
+    }
+  })
+
+  t.true(fs.pathExistsSync(t.context.folder))
+  t.is(files.length, 3)
+})
+
+test('works with templates.source defined as function (array paths)', async t => {
+  const {files} = await Maizzle.build('production', {
+    build: {
+      fail: 'silent',
+      templates: {
+        source: () => ['test/stubs/templates', 'test/stubs/templates'],
         destination: {
           path: t.context.folder
         }


### PR DESCRIPTION
Add support for defining `templates.source` as an array, i.e.:

```js
module.exports = {
  build: {
    templates: {
      source: ['src/some/templates', 'src/other/templates'],
      // ...
    }
  }
}
```
