### PR TITLE
refactor: stop disabling or adding tailwind plugins in core

### DIFF
--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -38,22 +38,7 @@ module.exports = {
           './src/**/*.*',
           {raw: html, extension: 'html'}
         ]
-      },
-      corePlugins: {
-        preflight: false,
-        animation: false,
-        backgroundOpacity: false,
-        borderOpacity: false,
-        boxShadow: false,
-        divideOpacity: false,
-        placeholderOpacity: false,
-        ringColor: false,
-        ringWidth: false,
-        ringOpacity: false,
-        ringOffsetColor: false,
-        textOpacity: false
-      },
-      plugins: []
+      }
     }, userConfig())
 
     // Add back the `{raw: html}` option if user provided own config
@@ -80,12 +65,6 @@ module.exports = {
 
       config.content.files.push(...templateSources)
     }
-
-    // Merge user's Tailwind plugins with our default ones
-    config.plugins = [
-      ...config.plugins,
-      require('tailwindcss-box-shadow')
-    ]
 
     const userFilePath = get(maizzleConfig, 'build.tailwind.css', path.join(process.cwd(), 'src/css/tailwind.css'))
     const userFileExists = await fs.pathExists(userFilePath)


### PR DESCRIPTION
This PR disables handling of Tailwind plugins in the framework core, in favor of handling it in the project's `tailwind.config.js`.

The main reason is that this is currently the only way to have Tailwind CSS Intellisense correctly handle the plugins added or disabled.