### PR TITLE
feat: expose config to template sources as function

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -49,7 +49,7 @@ module.exports = async (env, spinner, config) => {
     const templateTypeErrorMessage = 'Invalid template source: expected string or array of strings, got '
 
     if (typeof templateConfig.source === 'function') {
-      const sources = templateConfig.source()
+      const sources = templateConfig.source(config)
       if (Array.isArray(sources)) {
         templateSource.push(...sources)
       } else if (typeof sources === 'string') {

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -60,6 +60,19 @@ module.exports = {
       const templateSources = templateObjects.map(template => {
         const source = get(template, 'source')
 
+        if (typeof source === 'function') {
+          const sources = source(maizzleConfig)
+
+          if (Array.isArray(sources)) {
+            sources.map(s => config.content.files.push(s))
+          } else if (typeof sources === 'string') {
+            config.content.files.push(sources)
+          }
+
+          // Must return a valid `content` entry
+          return {raw: '', extension: 'html'}
+        }
+
         return `${source}/**/*.*`
       })
 

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -446,8 +446,11 @@ test('works with templates.source defined as function (array paths)', async t =>
   const {files} = await Maizzle.build('maizzle-ci', {
     build: {
       fail: 'silent',
+      customSources: ['test/stubs/templates', 'test/stubs/templates'],
       templates: {
-        source: () => ['test/stubs/templates', 'test/stubs/templates'],
+        source: config => {
+          return config.build.customSources
+        },
         destination: {
           path: t.context.folder
         }


### PR DESCRIPTION
This PR exposes the Maizzle `config` object to your template `source` when used as a method.

For example, you could do this in your `config.js`:

```js
build: {
  customSources: ['src/templates', 'some/path/templates'],
  templates: {
    source: config => {
      return config.build.customSources
    },
  // ...
  }
}
```

The `source` function must return a string path or an array of string paths.

These paths will be automatically added to Tailwind's `content.files` list, so selectors in files there will be preserved/generated.

Closes #560 