### PR TITLE
feat: support file path sources

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -69,8 +69,15 @@ module.exports = async (env, spinner, config) => {
 
     // Parse each template source
     await asyncForEach(templateSource, async source => {
+      /**
+       * Copy single-file sources correctly
+       * If `src` is a file, `dest` cannot be a directory
+       * https://github.com/jprichardson/node-fs-extra/issues/323
+       */
+      const out = fs.lstatSync(source).isFile() ? `${outputDir}/${path.basename(source)}` : outputDir
+
       await fs
-        .copy(source, outputDir)
+        .copy(source, out)
         .then(async () => {
           const extensions = Array.isArray(templateConfig.filetypes)
             ? templateConfig.filetypes.join('|')

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -73,6 +73,13 @@ module.exports = {
           return {raw: '', extension: 'html'}
         }
 
+        // Support single-file sources i.e. src/templates/index.html
+        if (typeof source === 'string' && Boolean(path.extname(source))) {
+          config.content.files.push(source)
+
+          return {raw: '', extension: 'html'}
+        }
+
         return `${source}/**/*.*`
       })
 

--- a/test/test-tailwind.js
+++ b/test/test-tailwind.js
@@ -64,7 +64,7 @@ test('works with custom `files` sources', async t => {
   t.true(css.includes('.hidden'))
 })
 
-test('uses maizzle template paths when purging', async t => {
+test('uses maizzle template path as content source', async t => {
   const css = await Tailwind.compile(
     '@tailwind utilities;',
     '<div></div>',
@@ -73,6 +73,23 @@ test('uses maizzle template paths when purging', async t => {
       build: {
         templates: {
           source: './test/stubs/tailwind'
+        }
+      }
+    }
+  )
+
+  t.true(css.includes('.hidden'))
+})
+
+test('uses maizzle template path as content source (single file)', async t => {
+  const css = await Tailwind.compile(
+    '@tailwind utilities;',
+    '<div></div>',
+    {},
+    {
+      build: {
+        templates: {
+          source: './test/stubs/tailwind/preserve.html'
         }
       }
     }


### PR DESCRIPTION
This PR adds support for file path sources, so you can compile just one template when developing locally with the `maizzle build` command:

```js
module.exports = {
  build: {
    templates: {
      source: 'src/templates/index.html',
      destination: {
        path: 'build_local',
      },
    },
  }
}
```
