### PR TITLE
fix: appending user css file

### DIFF
--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -90,7 +90,7 @@ module.exports = {
     const userFileExists = await fs.pathExists(userFilePath)
 
     if (userFileExists) {
-      css = await fs.readFile(path.resolve(userFilePath), 'utf8') + css
+      css += await fs.readFile(path.resolve(userFilePath), 'utf8')
     }
 
     return postcss([


### PR DESCRIPTION
This PR fixes an issue with how user CSS was merged with the default to-be-compiled Tailwind CSS string.

The problem was that doing this:

```js
css = await fs.readFile(path.resolve(userFilePath), 'utf8') + css
```

... resulted in the compiled CSS containing `@tailwind` directives, which were in turn preventing the Juice CSS inliner from working correctly (for example, `m-0` classes were never inlined; possibly others, too).