### PR TITLE
refactor: shorthand inline css transformer

### DIFF
--- a/src/transformers/index.js
+++ b/src/transformers/index.js
@@ -58,6 +58,6 @@ exports.attributeToStyle = (html, config) => attributeToStyle(html, config, true
 exports.removeInlineSizes = (html, config) => removeInlineSizes(html, config, true)
 exports.applyBaseImageUrl = (html, config) => applyBaseImageUrl(html, config, true)
 exports.removeInlinedClasses = (html, config) => removeInlinedClasses(html, config)
-exports.shorthandInlineCSS = (html, config) => shorthandInlineCSS(html, config)
+exports.shorthandInlineCSS = (html, config) => shorthandInlineCSS(html, config, true)
 exports.removeInlineBgColor = (html, config) => removeInlineBgColor(html, config, true)
 exports.applyExtraAttributes = (html, config) => applyExtraAttributes(html, config, true)

--- a/src/transformers/shorthandInlineCSS.js
+++ b/src/transformers/shorthandInlineCSS.js
@@ -2,8 +2,9 @@ const posthtml = require('posthtml')
 const {get, isObject, isEmpty} = require('lodash')
 const mergeLonghand = require('posthtml-postcss-merge-longhand')
 
-module.exports = async (html, config = {}) => {
-  config = get(config, 'shorthandInlineCSS', [])
+module.exports = async (html, config, direct = false) => {
+  config = direct ? (isObject(config) ? config : true) : get(config, 'shorthandInlineCSS', [])
+
   const posthtmlOptions = get(config, 'build.posthtml.options', {})
 
   if (typeof config === 'boolean' && config) {
@@ -11,7 +12,7 @@ module.exports = async (html, config = {}) => {
   }
 
   if (isObject(config) && !isEmpty(config)) {
-    html = await posthtml([mergeLonghand({tags: config})]).process(html, posthtmlOptions).then(result => result.html)
+    html = await posthtml([mergeLonghand(config)]).process(html, posthtmlOptions).then(result => result.html)
   }
 
   return html

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -492,18 +492,18 @@ test('shorthand inline css', async t => {
     <div style="padding: 2px;">padding</div>
     <div style="margin: 2px;">margin</div>
     <div style="border: 1px solid #000;">border</div>
-    <p style="border-width: 1px; border-style: solid; border-color: #000;">border</p>
+    <p style="border: 1px solid #000;">border</p>
   `
 
   const expect2 = `
     <div style="padding: 2px;">padding</div>
     <div style="margin: 2px;">margin</div>
     <div style="border: 1px solid #000;">border</div>
-    <p style="border: 1px solid #000;">border</p>
+    <p style="border-width: 1px; border-style: solid; border-color: #000;">border</p>
   `
 
-  const result = await Maizzle.shorthandInlineCSS(html, {shorthandInlineCSS: ['div']})
-  const result2 = await Maizzle.shorthandInlineCSS(html, {shorthandInlineCSS: true})
+  const result = await Maizzle.shorthandInlineCSS(html)
+  const result2 = await Maizzle.shorthandInlineCSS(html, {tags: ['div']})
 
   t.is(result, expect)
   t.is(result2, expect2)


### PR DESCRIPTION
This PR simplifies direct usage of the `shorthandInlineCSS` Transformer.

Apply to all tags in the HTML string:

```js
await Maizzle.shorthandInlineCSS(`html string`)
```

Specify which tags to apply to:

```js 
await Maizzle.shorthandInlineCSS(`html string`, {tags: ['div']})
```