### PR TITLE
fix: ignoring expressions in front matter

### DIFF
--- a/src/generators/output/to-string.js
+++ b/src/generators/output/to-string.js
@@ -24,11 +24,7 @@ module.exports = async (html, options) => {
   const tailwindConfig = get(options, 'tailwind.config', {})
   const cssString = get(options, 'tailwind.css', '')
 
-  let {frontmatter} = fm(html)
-
-  if (frontmatter) {
-    frontmatter = await posthtml(frontmatter, config)
-  }
+  const {frontmatter} = fm(html)
 
   html = `---\n${frontmatter}\n---\n\n${fm(html).body}`
 


### PR DESCRIPTION
This PR fixes an issue where we were evaluating expressions defined in front matter twice, which lead to issues with ignoring expressions through `@{{ }}` syntax.

You can now basically escape expressions in front matter without having to do it in the template/layout as well:

**src/layouts/example.html**

```html
Greeting escaped in front matter, rendered as usual in layout: {{ page.greeting }}

<block name="template"></block>
```

**src/templates/example.html**

```html
---
greeting: "Hello @{{ firstname or 'friend' }}"
---

<extends src="src/layouts/example.html">
  <block name="template">
    <div>
      {{ page.greeting }}
    </div>
  </block>
</extends>
```

Result:

```html
Greeting escaped in front matter, rendered as usual in layout: Hello {{ firstname or 'friend' }}

<div>
  Hello {{ firstname or 'friend' }}
</div>

