### PR TITLE
fix: don't watch tailwind config if object in serve()

### DIFF
--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -43,8 +43,7 @@ const serve = async (env = 'local', config = {}) => {
       'src/**',
       ...new Set(get(config, 'build.browsersync.watch', []))
     ]
-    const isTailwindConfigPath = !isObject(tailwindConfig)
-    if (isTailwindConfigPath) {
+    if (typeof tailwindConfig === "string") {
       globalPaths.push(tailwindConfig);
     }
 

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -38,11 +38,15 @@ const serve = async (env = 'local', config = {}) => {
     templates = Array.isArray(templates) ? templates : [templates]
 
     const templatePaths = [...new Set(templates.map(config => `${get(config, 'source', 'src')}/**`))]
+    const tailwindConfig = get(config, 'build.tailwind.config', 'tailwind.config.js')
     const globalPaths = [
       'src/**',
-      get(config, 'build.tailwind.config', 'tailwind.config.js'),
       ...new Set(get(config, 'build.browsersync.watch', []))
     ]
+    const isTailwindConfigPath = !isObject(tailwindConfig)
+    if(isTailwindConfigPath) {
+      globalPaths.push(tailwindConfig);
+    }
 
     // Watch for Template file changes
     browsersync()

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -44,7 +44,7 @@ const serve = async (env = 'local', config = {}) => {
       ...new Set(get(config, 'build.browsersync.watch', []))
     ]
     const isTailwindConfigPath = !isObject(tailwindConfig)
-    if(isTailwindConfigPath) {
+    if (isTailwindConfigPath) {
       globalPaths.push(tailwindConfig);
     }
 

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -43,7 +43,7 @@ const serve = async (env = 'local', config = {}) => {
       'src/**',
       ...new Set(get(config, 'build.browsersync.watch', []))
     ]
-    if (typeof tailwindConfig === "string") {
+    if (typeof tailwindConfig === 'string') {
       globalPaths.push(tailwindConfig);
     }
 


### PR DESCRIPTION
This PR enables the tailwind config to be passed directly as object to the serve() function. Currently it won't work because the tailwind config object would be added as path to `globalPaths`

```javascript
Maizzle.serve("local", {
    build: {
        ...someMaizzleConfig,
        tailwind:{
            config:{
                ...theTailwindConfigAsObject
            }
        }
});
```