### PR TITLE
feat: config.build.current

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -96,6 +96,8 @@ module.exports = async (env, spinner, config) => {
           }
 
           await asyncForEach(templates, async file => {
+            config.build.current = path.parse(file)
+
             const html = await fs.readFile(file, 'utf8')
 
             try {

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -509,3 +509,32 @@ test('throws if templates path is invalid (function)', async t => {
     })
   }, {instanceOf: TypeError})
 })
+
+test('sets config.build.current', async t => {
+  await Maizzle.build('maizzle-ci', {
+    build: {
+      fail: 'silent',
+      templates: {
+        source: 'test/stubs/templates',
+        destination: {
+          path: t.context.folder
+        }
+      }
+    },
+    events: {
+      beforeRender(html, config) {
+        t.context.current = config.build.current
+
+        return html
+      }
+    }
+  })
+
+  t.deepEqual(t.context.current, {
+    root: '',
+    dir: t.context.folder,
+    base: '1.html',
+    ext: '.html',
+    name: '1'
+  })
+})


### PR DESCRIPTION
This PR adds `config.build.current`, an object containing a parsed path of the currently-processed template:

```js
{
    root: '',
    dir: 'build_production',
    base: 'example.html',
    ext: '.html',
    name: 'example'
}
```

Since Maizzle copies the source files to destination and then compiles them there, the parsed path is your `build.templates.destination.path`, hence the `build_production` directory.

Also, this is only available when using the CLI with `maizzle build` - there's no source file path when using the API.