### PR TITLE
fix: pass expressions options to components

### DIFF
--- a/src/generators/posthtml.js
+++ b/src/generators/posthtml.js
@@ -47,6 +47,7 @@ module.exports = async (html, config) => {
       )
     ),
     modules({
+      expressions: expressionsOptions,
       parser: posthtmlOptions,
       attributeAsLocals: true,
       from: modulesFrom,


### PR DESCRIPTION
This PR fixes an issue where expressions options were not being passed down to components.
