### PR TITLE
fix: tailwind compiled string path

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -26,8 +26,8 @@ module.exports = async (env, spinner, config) => {
   const parsed = []
   let files = []
 
-  const css = (typeof get(config, 'tailwind.compiled') === 'string')
-    ? config.tailwind.compiled
+  const css = (typeof get(config, 'build.tailwind.compiled') === 'string')
+    ? config.build.tailwind.compiled
     : await Tailwind.compile('', '', {}, config, spinner)
 
   // Parse each template config object


### PR DESCRIPTION
This PR fixes an issue where providing a pre-compiled CSS string in order to skip Tailwind CSS compilation was not working because we were checking for it in the wrong place.

You may now do this in your Maizzle `config.js` if you want to skip Tailwind CSS compilation:

```js
module.exports = {
  build: {
    tailwind: {
      compiled: '',
    }
  }
}
```
