### PR TITLE
fix: don't require _options for urlParameters transformer

### DIFF
--- a/src/transformers/urlParameters.js
+++ b/src/transformers/urlParameters.js
@@ -6,11 +6,11 @@ module.exports = async (html, config = {}, direct = false) => {
   const urlParameters = direct ? config : get(config, 'urlParameters', {})
 
   if (!isEmpty(urlParameters)) {
-    const {_options, ...parameters} = urlParameters
-    const tags = _options.tags ?? ['a']
-    const strict = _options.strict ?? true
-    const qs = _options.qs ?? {encode: false}
     const posthtmlOptions = get(config, 'build.posthtml.options', {})
+    const {_options, ...parameters} = urlParameters
+    const tags = get(_options, 'tags', ['a'])
+    const strict = get(_options, 'strict', true)
+    const qs = get(_options, 'qs', {encode: false})
 
     return posthtml([urlParams({parameters, tags, qs, strict})]).process(html, posthtmlOptions).then(result => result.html)
   }

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -315,20 +315,35 @@ test('filters (postcss)', async t => {
 })
 
 test('url parameters', async t => {
-  const html = await Maizzle.addURLParams(
-    `<a href="example.com">test</a>
+  const simple = await Maizzle.addURLParams(
+    `<a href="https://example.com">test</a>
       <link href="https://foo.bar">`,
     {
-      _options: {
-        tags: ['a[href*="example"]'],
-        strict: false
-      },
       bar: 'baz',
       qix: 'qux'
     }
   )
 
-  t.is(html, `<a href="example.com?bar=baz&qix=qux">test</a>
+  const withOptions = await Maizzle.addURLParams(
+    `<a href="example.com">test</a>
+      <link href="https://foo.bar">`,
+    {
+      _options: {
+        tags: ['a[href*="example"]'],
+        strict: false,
+        qs: {
+          encode: true
+        }
+      },
+      foo: '@Bar@',
+      bar: 'baz'
+    }
+  )
+
+  t.is(simple, `<a href="https://example.com?bar=baz&qix=qux">test</a>
+      <link href="https://foo.bar">`)
+
+  t.is(withOptions, `<a href="example.com?bar=baz&foo=%40Bar%40">test</a>
       <link href="https://foo.bar">`)
 })
 


### PR DESCRIPTION
This PR fixes #771, where if you didn't provide the `_options` object to the `urlParameters` transformer in addition to the parameters that you wanted apended to URLs, the build would fail.
