### PR TITLE
fix: tailwindcss content sources

### DIFF
--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -35,7 +35,8 @@ module.exports = {
       important: true,
       content: {
         files: [
-          './src/**/*.*',
+          './src/components/**.html',
+          './src/layouts/**.html',
           {raw: html, extension: 'html'}
         ]
       }
@@ -46,7 +47,6 @@ module.exports = {
       config.content = {
         files: [
           ...config.content,
-          './src/**/*.*',
           {raw: html, extension: 'html'}
         ]
       }

--- a/test/test-tailwindcss.js
+++ b/test/test-tailwindcss.js
@@ -111,5 +111,5 @@ test('uses custom postcss plugins from the maizzle config', async t => {
   const css = await Tailwind.compile('.test {transform: scale(0.5)}', '<div class="test">Test</a>', {}, maizzleConfig)
 
   t.not(css, undefined)
-  t.is(css.trim(), '.inline {display: inline !important} .table {display: table !important} .contents {display: contents !important} .truncate {overflow: hidden !important;text-overflow: ellipsis !important;white-space: nowrap !important} .uppercase {text-transform: uppercase !important} .lowercase {text-transform: lowercase !important} .capitalize {text-transform: capitalize !important} .test {-webkit-transform: scale(0.5);transform: scale(0.5)}')
+  t.is(css.trim(), '.test {-webkit-transform: scale(0.5);transform: scale(0.5)}')
 })


### PR DESCRIPTION
This PR fixes a performance issue where we always included `./src/**/*.*` in the `content` array when compiling Tailwind CSS.

This not only included a very broad pattern, but started significantly slowing builds down as more files were added to the `src` folder. It was especially noticeable when image files were added to `./src/assets`.

Now, the default `content` sources are:

```js
content: {
  files: [
    './src/components/**.html',
    './src/layouts/**.html',
    {raw: html, extension: 'html'}
  ]
}
```

... where `html` is the HTML string currently being processed.

If you add your own `content` key to `tailwind.config.js`, this will be overwritten to:

```js
{
  files: [
    ...config.content,
    {raw: html, extension: 'html'}
  ]
}
```

... meaning that you need to make sure to also add any paths to Components or Layouts:

```js
// tailwind.config.js

module.exports = {
  content: [
    './src/components/**.html',
    './src/layouts/**.html',
    // other content sources...
  ],
}
```