### PR TITLE
fix: disabling safeClassNames transformer

### DIFF
--- a/src/transformers/filters/index.js
+++ b/src/transformers/filters/index.js
@@ -22,11 +22,16 @@ module.exports = async (html, config = {}, direct = false) => {
   filters.postcss = css => PostCSS.process(css, maizzleConfig)
   filters.tailwindcss = css => Tailwind.compile(css, html, tailwindConfig, maizzleConfig)
 
-  return posthtml([
+  const posthtmlPlugins = [
     styleDataEmbed(),
-    posthtmlContent(filters),
-    safeClassNames()
-  ])
+    posthtmlContent(filters)
+  ]
+
+  if (get(config, 'safeClassNames') !== false) {
+    posthtmlPlugins.push(safeClassNames())
+  }
+
+  return posthtml(posthtmlPlugins)
     .process(html, posthtmlOptions)
     .then(result => result.html)
 }


### PR DESCRIPTION
This PR fixes #782, an issue where the `safeClassNames` transformer could not be disabled even when it was correctly set to `false` in the config.