### PR TITLE
refactor: use default posthtml options

### DIFF
--- a/src/generators/plaintext.js
+++ b/src/generators/plaintext.js
@@ -1,11 +1,12 @@
 const path = require('path')
-const {get} = require('lodash')
 const posthtml = require('posthtml')
+const {get, merge} = require('lodash')
 const {stripHtml} = require('string-strip-html')
+const defaultConfig = require('./posthtml/defaultConfig')
 
 const self = {
   handleCustomTags: (html, config = {}) => {
-    const posthtmlOptions = get(config, 'build.posthtml.options', {})
+    const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
 
     const posthtmlPlugin = () => tree => {
       const process = node => {

--- a/src/generators/posthtml/defaultConfig.js
+++ b/src/generators/posthtml/defaultConfig.js
@@ -1,0 +1,3 @@
+module.exports = {
+  recognizeNoValueAttribute: true
+}

--- a/src/generators/posthtml/index.js
+++ b/src/generators/posthtml/index.js
@@ -4,6 +4,7 @@ const {get, merge} = require('lodash')
 const fetch = require('posthtml-fetch')
 const layouts = require('posthtml-extend')
 const modules = require('posthtml-modules')
+const defaultConfig = require('./defaultConfig')
 const expressions = require('posthtml-expressions')
 
 module.exports = async (html, config) => {
@@ -14,7 +15,7 @@ module.exports = async (html, config) => {
   const modulesRoot = modulesOptions.root || './'
   const modulesFrom = modulesOptions.from || `${modulesRoot}/fake`
 
-  const posthtmlOptions = merge({recognizeNoValueAttribute: true}, get(config, 'build.posthtml.options', {}))
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
   const posthtmlPlugins = get(config, 'build.posthtml.plugins', [])
 
   const expressionsOptions = merge({strictMode: false}, get(config, 'build.posthtml.expressions', {}))

--- a/src/transformers/attributeToStyle.js
+++ b/src/transformers/attributeToStyle.js
@@ -1,9 +1,10 @@
 const posthtml = require('posthtml')
 const parseAttrs = require('posthtml-attrs-parser')
-const {get, forEach, intersection, keys, isEmpty} = require('lodash')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
+const {get, merge, forEach, intersection, keys, isEmpty} = require('lodash')
 
 module.exports = async (html, config = {}, direct = false) => {
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
   const attributes = get(config, 'inlineCSS.attributeToStyle', false)
 
   if (typeof attributes === 'boolean' && attributes) {

--- a/src/transformers/extraAttributes.js
+++ b/src/transformers/extraAttributes.js
@@ -1,13 +1,14 @@
 const posthtml = require('posthtml')
-const {get, isObject} = require('lodash')
+const {get, merge, isObject} = require('lodash')
 const addAttributes = require('posthtml-extra-attributes')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
   if (get(config, 'extraAttributes') === false) {
     return html
   }
 
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
 
   let attributes = {
     table: {

--- a/src/transformers/filters/index.js
+++ b/src/transformers/filters/index.js
@@ -5,13 +5,14 @@ const PostCSS = require('../../generators/postcss')
 const posthtmlContent = require('posthtml-content')
 const Tailwind = require('../../generators/tailwindcss')
 const safeClassNames = require('posthtml-safe-class-names')
+const defaultConfig = require('../../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
   const filters = direct ?
     merge(defaultFilters, config) :
     merge(defaultFilters, get(config, 'filters', {}))
 
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
 
   /**
    * Compile CSS in <style {post|tailwind}css> tags

--- a/src/transformers/markdown.js
+++ b/src/transformers/markdown.js
@@ -1,6 +1,7 @@
 const posthtml = require('posthtml')
 const {get, merge} = require('lodash')
 const markdown = require('posthtml-markdownit')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
   if (get(config, 'markdown') === false) {
@@ -8,7 +9,7 @@ module.exports = async (html, config = {}, direct = false) => {
   }
 
   const userMarkdownOptions = direct ? config : get(config, 'markdown', {})
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
   const markdownOptions = merge({markdownit: {html: true}}, userMarkdownOptions)
 
   return posthtml([

--- a/src/transformers/posthtmlMso.js
+++ b/src/transformers/posthtmlMso.js
@@ -1,10 +1,11 @@
-const {get} = require('lodash')
 const posthtml = require('posthtml')
+const {get, merge} = require('lodash')
 const outlook = require('posthtml-mso')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config) => {
   const outlookOptions = get(config, 'build.posthtml.outlook', {})
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
 
   return posthtml([outlook({...outlookOptions})]).process(html, posthtmlOptions).then(result => result.html)
 }

--- a/src/transformers/preventWidows.js
+++ b/src/transformers/preventWidows.js
@@ -1,13 +1,14 @@
 const posthtml = require('posthtml')
-const {get, isEmpty} = require('lodash')
+const {get, merge, isEmpty} = require('lodash')
 const {removeWidows} = require('string-remove-widows')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}) => {
   if (isEmpty(config)) {
     return removeWidows(html).res
   }
 
-  const posthtmlOptions = get(config, 'build.posthtml.options', {recognizeNoValueAttribute: true})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
 
   return posthtml([removeWidowsPlugin(config)]).process(html, posthtmlOptions).then(result => result.html)
 }

--- a/src/transformers/removeAttributes.js
+++ b/src/transformers/removeAttributes.js
@@ -1,10 +1,11 @@
-const {get} = require('lodash')
 const posthtml = require('posthtml')
+const {get, merge} = require('lodash')
 const removeAttributes = require('posthtml-remove-attributes')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
   const attributes = direct ? (Array.isArray(config) ? [...config] : []) : get(config, 'removeAttributes', [])
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
 
   attributes.push({name: 'style'}, {name: 'class'})
 

--- a/src/transformers/removeInlineBackgroundColor.js
+++ b/src/transformers/removeInlineBackgroundColor.js
@@ -1,10 +1,11 @@
 const posthtml = require('posthtml')
-const {get, isEmpty} = require('lodash')
+const {get, merge, isEmpty} = require('lodash')
 const parseAttrs = require('posthtml-attrs-parser')
 const {toStyleString} = require('../utils/helpers')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
 
   if (isEmpty(config)) {
     return posthtml([removeInlineBGColor()]).process(html, posthtmlOptions).then(result => result.html)

--- a/src/transformers/removeInlineSizes.js
+++ b/src/transformers/removeInlineSizes.js
@@ -1,13 +1,15 @@
 const posthtml = require('posthtml')
-const {get, isEmpty} = require('lodash')
+const {get, merge, isEmpty} = require('lodash')
 const parseAttrs = require('posthtml-attrs-parser')
 const {toStyleString} = require('../utils/helpers')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
   const settings = direct ? config : get(config, 'inlineCSS.keepOnlyAttributeSizes', {})
 
   if (!isEmpty(settings)) {
-    const posthtmlOptions = get(config, 'build.posthtml.options', {})
+    const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
+
     return posthtml([removeInlineSizes(settings)]).process(html, posthtmlOptions).then(result => result.html)
   }
 

--- a/src/transformers/removeInlinedSelectors.js
+++ b/src/transformers/removeInlinedSelectors.js
@@ -1,15 +1,17 @@
-const {get, has, remove} = require('lodash')
 const postcss = require('postcss')
 const posthtml = require('posthtml')
+const {get, merge, has, remove} = require('lodash')
 const parseAttrs = require('posthtml-attrs-parser')
 const matchHelper = require('posthtml-match-helper')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}) => {
   if (get(config, 'removeInlinedClasses') === false) {
     return html
   }
 
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
+
   return posthtml([plugin(posthtmlOptions)]).process(html, posthtmlOptions).then(result => result.html)
 }
 

--- a/src/transformers/replaceStrings.js
+++ b/src/transformers/replaceStrings.js
@@ -1,4 +1,4 @@
-const {isEmpty, get} = require('lodash')
+const {get, isEmpty} = require('lodash')
 
 module.exports = async (html, config = {}, direct = false) => {
   const replacements = direct ? config : get(config, 'replaceStrings', {})

--- a/src/transformers/safeClassNames.js
+++ b/src/transformers/safeClassNames.js
@@ -1,6 +1,7 @@
-const {get} = require('lodash')
 const posthtml = require('posthtml')
+const {get, merge} = require('lodash')
 const safeClassNames = require('posthtml-safe-class-names')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
   const option = get(config, 'safeClassNames')
@@ -17,7 +18,7 @@ module.exports = async (html, config = {}, direct = false) => {
     return html
   }
 
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
   const replacements = direct ? config : get(config, 'safeClassNames', {})
 
   return posthtml([safeClassNames({replacements})]).process(html, posthtmlOptions).then(result => result.html)

--- a/src/transformers/shorthandInlineCSS.js
+++ b/src/transformers/shorthandInlineCSS.js
@@ -1,11 +1,12 @@
 const posthtml = require('posthtml')
-const {get, isObject, isEmpty} = require('lodash')
+const {get, merge, isObject, isEmpty} = require('lodash')
 const mergeLonghand = require('posthtml-postcss-merge-longhand')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config, direct = false) => {
   config = direct ? (isObject(config) ? config : true) : get(config, 'shorthandInlineCSS', [])
 
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
 
   if (typeof config === 'boolean' && config) {
     html = await posthtml([mergeLonghand()]).process(html, posthtmlOptions).then(result => result.html)

--- a/src/transformers/sixHex.js
+++ b/src/transformers/sixHex.js
@@ -1,13 +1,15 @@
-const {get} = require('lodash')
 const posthtml = require('posthtml')
+const {get, merge} = require('lodash')
 const {conv} = require('color-shorthand-hex-to-six-digit')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}) => {
   if (get(config, 'sixHex') === false) {
     return html
   }
 
-  const posthtmlOptions = get(config, 'build.posthtml.options', {})
+  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
+
   return posthtml([sixHex()]).process(html, posthtmlOptions).then(result => result.html)
 }
 

--- a/src/transformers/urlParameters.js
+++ b/src/transformers/urlParameters.js
@@ -1,12 +1,13 @@
 const posthtml = require('posthtml')
-const {get, isEmpty} = require('lodash')
+const {get, merge, isEmpty} = require('lodash')
 const urlParams = require('posthtml-url-parameters')
+const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
   const urlParameters = direct ? config : get(config, 'urlParameters', {})
 
   if (!isEmpty(urlParameters)) {
-    const posthtmlOptions = get(config, 'build.posthtml.options', {})
+    const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
     const {_options, ...parameters} = urlParameters
     const tags = get(_options, 'tags', ['a'])
     const strict = get(_options, 'strict', true)

--- a/test/expected/transformers/base-url.html
+++ b/test/expected/transformers/base-url.html
@@ -39,7 +39,7 @@
     <video width="250" poster="https://example.com/flower.jpg">
       <source src="https://example.com/media/flower.webm" type="video/webm">
       <source src="https://example.tv/media/flower.mp4" type="video/mp4">
-      <track default="" kind="captions" srclang="en" src="https://example.com/media/tracks/friday.vtt">
+      <track default kind="captions" srclang="en" src="https://example.com/media/tracks/friday.vtt">
     </video>
 
     <audio src="https://example.com/media/sample.mp3">

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -534,10 +534,8 @@ test('remove inlined selectors', async t => {
 
   const basic = await Maizzle.removeInlinedClasses(html)
 
-  const expectedBasic = expectedWithOptions.replace('no-value', 'no-value=""')
-
   t.is(withPostHTMLOptions, expectedWithOptions)
-  t.is(basic, expectedBasic)
+  t.is(basic, expectedWithOptions)
 })
 
 test('remove inlined selectors (disabled)', async t => {


### PR DESCRIPTION
This PR adds default PostHTML options, helping fix an issue with valueless attributes like `<div data-id>` being rewritten to contain an empty value, i.e. `<div data-id=""`.