### PR TITLE
fix: respect config.js root paths in tailwindcss content sources

### DIFF
--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -35,8 +35,8 @@ module.exports = {
       important: true,
       content: {
         files: [
-          './src/components/**.html',
-          './src/layouts/**.html',
+          `${get(maizzleConfig, 'build.components.root', './src/components')}/**/*.html`,
+          `${get(maizzleConfig, 'build.layouts.root', './src/layouts')}/**/*.html`,
           {raw: html, extension: 'html'}
         ]
       }

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -38,8 +38,12 @@ module.exports = {
       important: true,
       content: {
         files: [
-          typeof layoutsRoot === 'string' ? path.normalize(`${layoutsRoot}/**/*.html`) : './src/layouts/**/*.html',
-          typeof componentsRoot === 'string' ? path.normalize(`${componentsRoot}/**/*.html`) : './src/components/**/*.html',
+          typeof layoutsRoot === 'string' && layoutsRoot ?
+            `${layoutsRoot}/**/*.html`.replace(/\/\//g, '/') :
+            './src/layouts/**/*.html',
+          typeof componentsRoot === 'string' && componentsRoot ?
+            `${componentsRoot}/**/*.html`.replace(/\/\//g, '/') :
+            './src/components/**/*.html',
           {raw: html, extension: 'html'}
         ]
       }

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -31,12 +31,15 @@ module.exports = {
     }
 
     // Merge user's Tailwind config on top of a 'base' config
+    const layoutsRoot = get(maizzleConfig, 'build.layouts.root')
+    const componentsRoot = get(maizzleConfig, 'build.components.root')
+
     const config = merge({
       important: true,
       content: {
         files: [
-          `${get(maizzleConfig, 'build.components.root', './src/components')}/**/*.html`,
-          `${get(maizzleConfig, 'build.layouts.root', './src/layouts')}/**/*.html`,
+          typeof layoutsRoot === 'string' ? path.normalize(`${layoutsRoot}/**/*.html`) : './src/layouts/**/*.html',
+          typeof componentsRoot === 'string' ? path.normalize(`${componentsRoot}/**/*.html`) : './src/components/**/*.html',
           {raw: html, extension: 'html'}
         ]
       }


### PR DESCRIPTION
This PR fixes an issue with the default Tailwind CSS content sources when a user customized root paths for components and layouts. If you change/add `build.components.root` or `build.layouts.root` in your `config.js`, Tailwind will now correctly use those paths when generating CSS.