### PR TITLE
refactor: add default replacements for safeClassNames

### DIFF
--- a/src/transformers/filters/index.js
+++ b/src/transformers/filters/index.js
@@ -29,7 +29,12 @@ module.exports = async (html, config = {}, direct = false) => {
   ]
 
   if (get(config, 'safeClassNames') !== false) {
-    posthtmlPlugins.push(safeClassNames())
+    posthtmlPlugins.push(safeClassNames({
+      replacements: {
+        '{': '{',
+        '}': '}'
+      }
+    }))
   }
 
   return posthtml(posthtmlPlugins)

--- a/src/transformers/safeClassNames.js
+++ b/src/transformers/safeClassNames.js
@@ -19,7 +19,10 @@ module.exports = async (html, config = {}, direct = false) => {
   }
 
   const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
-  const replacements = direct ? config : get(config, 'safeClassNames', {})
+  const replacements = direct ? config : get(config, 'safeClassNames', {
+    '{': '{',
+    '}': '}'
+  })
 
   return posthtml([safeClassNames({replacements})]).process(html, posthtmlOptions).then(result => result.html)
 }


### PR DESCRIPTION
This PR helps fixe an issue with using expressions inside `class=""` attributes, where something like `class="{{ var }}"` was being compiled to `class=" var "` because the `safeClassNames` transformer was removing `{` and `}` from class names by default.
