### PR TITLE
fix: ensure href values in not-plaintext tags are removed

### DIFF
--- a/test/stubs/plaintext/plaintext.html
+++ b/test/stubs/plaintext/plaintext.html
@@ -1,5 +1,5 @@
 <div>Show in HTML</div>
 <plaintext>Show in plaintext</plaintext>
 <not-plaintext>
-  <table><tr><td>Remove from plaintext</td></tr></table>
+  <p>Do not show <a href="url">this</a> in plaintext.</p>
 </not-plaintext>

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -153,7 +153,7 @@ test('outputs plaintext files', async t => {
 
   t.is(
     await fs.readFile(`${t.context.folder}/plaintext.html`, 'utf8'),
-    '<div>Show in HTML</div>\n\n\n  <table><tr><td>Remove from plaintext</td></tr></table>\n\n'
+    '<div>Show in HTML</div>\n\n\n  <p>Do not show <a href="url">this</a> in plaintext.</p>\n\n'
   )
 })
 


### PR DESCRIPTION
This PR fixes #780 by completely removing any `<not-plaintext>` tags from the HTML used to generate the plaintext version.
