### PR TITLE
[4.x] Fixes issues with the inlineCSS transformer

### DIFF
--- a/src/transformers/inlineCss.js
+++ b/src/transformers/inlineCss.js
@@ -13,6 +13,7 @@ module.exports = async (html, config = {}, direct = false) => {
   const css = get(config, 'customCSS', false)
 
   if (get(config, 'inlineCSS') === true || !isEmpty(options)) {
+    options.applyAttributesTableElements = true
     juice.styleToAttribute = get(options, 'styleToAttribute', {'vertical-align': 'valign'})
 
     juice.widthElements = get(options, 'applyWidthAttributes', []).map(i => i.toUpperCase())

--- a/src/transformers/inlineCss.js
+++ b/src/transformers/inlineCss.js
@@ -15,8 +15,8 @@ module.exports = async (html, config = {}, direct = false) => {
   if (get(config, 'inlineCSS') === true || !isEmpty(options)) {
     juice.styleToAttribute = get(options, 'styleToAttribute', {'vertical-align': 'valign'})
 
-    juice.widthElements = get(options, 'applyWidthAttributes', [])
-    juice.heightElements = get(options, 'applyHeightAttributes', [])
+    juice.widthElements = get(options, 'applyWidthAttributes', []).map(i => i.toUpperCase())
+    juice.heightElements = get(options, 'applyHeightAttributes', []).map(i => i.toUpperCase())
 
     juice.excludedProperties = ['--tw-shadow']
 

--- a/src/transformers/inlineCss.js
+++ b/src/transformers/inlineCss.js
@@ -7,6 +7,8 @@ module.exports = async (html, config = {}, direct = false) => {
   }
 
   const options = direct ? config : get(config, 'inlineCSS', {})
+  // Default `removeStyleTags` to false so we can preserve
+  // CSS selectors that are not present in the HTML
   const removeStyleTags = get(options, 'removeStyleTags', false)
   const css = get(config, 'customCSS', false)
 
@@ -28,7 +30,9 @@ module.exports = async (html, config = {}, direct = false) => {
       })
     }
 
-    html = css ? juice.inlineContent(html, css, {removeStyleTags}) : juice(html, {removeStyleTags})
+    html = css ?
+      juice.inlineContent(html, css, {removeStyleTags, ...options}) :
+      juice(html, {removeStyleTags, ...options})
 
     return html
   }

--- a/src/transformers/removeInlineSizes.js
+++ b/src/transformers/removeInlineSizes.js
@@ -19,12 +19,11 @@ module.exports = async (html, config = {}, direct = false) => {
 const removeInlineSizes = (mappings = {}) => tree => {
   const process = node => {
     const attrs = parseAttrs(node.attrs)
-    const tag = node.tag ? node.tag.toUpperCase() : ''
 
     Object.entries(mappings).forEach(([attribute, tags]) => {
-      tags = Object.values(tags)
+      tags = Object.values(tags).map(tag => tag.toLowerCase())
 
-      if (!tags.includes(tag)) {
+      if (!tags.includes(node.tag)) {
         return node
       }
 

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -58,8 +58,15 @@ test('remove inline background-color (with tags)', async t => {
 })
 
 test('inline CSS', async t => {
-  const html = `<div class="foo bar">test</div>`
+  const html = `
+    <table class="w-1 h-1">
+      <tr>
+        <td class="foo bar h-1">test</td>
+      </tr>
+    </table>`
   const css = `
+    .w-1 {width: 4px}
+    .h-1 {height: 4px}
     .foo {color: red}
     .bar {cursor: pointer}
   `
@@ -70,8 +77,8 @@ test('inline CSS', async t => {
     styleToAttribute: {
       'text-align': 'align'
     },
-    applyWidthAttributes: ['TABLE'],
-    applyHeightAttributes: ['TD'],
+    applyWidthAttributes: ['table'],
+    applyHeightAttributes: ['td'],
     mergeLonghand: ['div'],
     excludedProperties: ['cursor'],
     codeBlocks: {
@@ -82,7 +89,12 @@ test('inline CSS', async t => {
     }
   })
 
-  t.is(result, '<div class="foo bar" style="color: red;">test</div>')
+  t.is(result, `
+    <table class="w-1 h-1" style="width: 4px; height: 4px;" width="4">
+      <tr>
+        <td class="foo bar h-1" style="height: 4px; color: red;" height="4">test</td>
+      </tr>
+    </table>`)
 })
 
 test('inline CSS (disabled)', async t => {

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -59,7 +59,7 @@ test('remove inline background-color (with tags)', async t => {
 
 test('inline CSS', async t => {
   const html = `
-    <table class="w-1 h-1">
+    <table class="w-1 h-1 text-center">
       <tr>
         <td class="foo bar h-1">test</td>
       </tr>
@@ -69,9 +69,24 @@ test('inline CSS', async t => {
     .h-1 {height: 4px}
     .foo {color: red}
     .bar {cursor: pointer}
+    .text-center {text-align: center}
   `
 
-  const result = await Maizzle.inlineCSS(html, {
+  const html2 = `
+  <html>
+    <head>
+      <style>${css}</style>
+    </head>
+    <body>
+      <table class="w-1 h-1 text-center">
+        <tr>
+          <td class="foo bar h-1">test</td>
+        </tr>
+      </table>
+    </body>
+  </html>`
+
+  const result1 = await Maizzle.inlineCSS(html, {
     customCSS: css,
     removeStyleTags: false,
     styleToAttribute: {
@@ -88,13 +103,49 @@ test('inline CSS', async t => {
       }
     }
   })
+  const result2 = await Maizzle.inlineCSS(html2, {
+    removeStyleTags: false,
+    styleToAttribute: {
+      'text-align': 'align'
+    },
+    applyWidthAttributes: ['table'],
+    applyHeightAttributes: ['td'],
+    mergeLonghand: ['div'],
+    excludedProperties: ['cursor'],
+    codeBlocks: {
+      RB: {
+        start: '<%',
+        end: '%>'
+      }
+    }
+  })
 
-  t.is(result, `
-    <table class="w-1 h-1" style="width: 4px; height: 4px;" width="4">
+  t.is(result1, `
+    <table class="w-1 h-1 text-center" style="width: 4px; height: 4px; text-align: center;" width="4" align="center">
       <tr>
         <td class="foo bar h-1" style="height: 4px; color: red;" height="4">test</td>
       </tr>
     </table>`)
+
+  t.is(result2, `
+  <html>
+    <head>
+      <style>
+    .w-1 {width: 4px}
+    .h-1 {height: 4px}
+    .foo {color: red}
+    .bar {cursor: pointer}
+    .text-center {text-align: center}
+  </style>
+    </head>
+    <body>
+      <table class="w-1 h-1 text-center" style="width: 4px; height: 4px; text-align: center;" width="4" align="center">
+        <tr>
+          <td class="foo bar h-1" style="height: 4px; color: red;" height="4">test</td>
+        </tr>
+      </table>
+    </body>
+  </html>`)
 })
 
 test('inline CSS (disabled)', async t => {

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -13,13 +13,24 @@ const expected = file => readFile('expected/transformers', file)
 
 test('remove inline sizes', async t => {
   const options = {
-    width: ['TD'],
-    height: ['TD']
+    width: ['table'],
+    height: ['td']
   }
 
-  const html = await Maizzle.removeInlineSizes('<td style="width:100%;height:10px;">test</td>', options)
+  const html = await Maizzle.removeInlineSizes(`
+    <table style="width: 10px; height: auto;">
+      <tr>
+        <td style="width: 100%; height: 10px;">test</td>
+      </tr>
+    </table>`,
+  options)
 
-  t.is(html, '<td style="">test</td>')
+  t.is(html, `
+    <table style="height: auto">
+      <tr>
+        <td style="width: 100%">test</td>
+      </tr>
+    </table>`)
 })
 
 test('remove inline background-color', async t => {


### PR DESCRIPTION
This PR fixes some issues with CSS inlining:

- fixed an issue where using lowercase tag names in `inlineCSS` did not work
- fixed an issue where `styleToAttribute` was not being applied
