### PR TITLE
feat: disable filters

### DIFF
--- a/src/transformers/filters/index.js
+++ b/src/transformers/filters/index.js
@@ -8,6 +8,10 @@ const safeClassNames = require('posthtml-safe-class-names')
 const defaultConfig = require('../../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
+  if (get(config, 'filters') === false) {
+    return html
+  }
+
   const filters = direct ?
     merge(defaultFilters, config) :
     merge(defaultFilters, get(config, 'filters', {}))

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -361,6 +361,12 @@ test('filters (default)', async t => {
   t.is(html, await expected('filters'))
 })
 
+test('filters (disabled)', async t => {
+  const html = await Maizzle.withFilters('<p uppercase>test</p>', {filters: false})
+
+  t.is(html, '<p uppercase>test</p>')
+})
+
 test('filters (tailwindcss)', async t => {
   const html = await Maizzle.withFilters(
     `<style tailwindcss>


### PR DESCRIPTION
This PR adds the ability to completely disable filters in Maizzle by setting the option to `false` in your `config.js`:

```js
module.exports = {
  filters: false,
}
```
