### PR TITLE
Add `shorthandCSS` to `postcss` transformer

### DIFF
--- a/src/generators/postcss.js
+++ b/src/generators/postcss.js
@@ -9,7 +9,9 @@ module.exports = {
     return postcss([
       postcssImport(),
       postcssNested(),
-      maizzleConfig.env === 'local' ? () => {} : mergeLonghand(),
+      get(maizzleConfig, 'shorthandCSS', get(maizzleConfig, 'shorthandInlineCSS')) === true ?
+        mergeLonghand() :
+        () => {},
       ...get(maizzleConfig, 'build.postcss.plugins', [])
     ])
       .process(css, {from: undefined})

--- a/test/test-tostring.js
+++ b/test/test-tostring.js
@@ -154,10 +154,12 @@ test('preserves css in marked style tags (tailwindcss)', async t => {
 })
 
 test('@import css files in marked style tags', async t => {
-  const source = `<style class="inline" postcss>@import "test/stubs/post.css";</style>`
-  const html = await renderString(source)
+  const source = `<style postcss>@import "test/stubs/post.css";</style>`
+  const html = await renderString(source, {
+    maizzle: {
+      shorthandCSS: true
+    }
+  })
 
-  t.is(html, `<style class="inline">div {
-  margin: 1px 2px 3px 4px;
-}</style>`)
+  t.is(html.replace(/\n {2,}/g, ''), `<style>div {margin: 1px 2px 3px 4px;\n}</style>`)
 })

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -360,7 +360,10 @@ test('filters (postcss)', async t => {
         margin-bottom: 3px;
         margin-left: 4px;
       }
-    </style>`
+    </style>`,
+    {
+      shorthandCSS: true
+    }
   )
 
   t.is(html.replace(/\n {2,}/g, ''), '<style>div {margin: 1px 2px 3px 4px;}</style>')


### PR DESCRIPTION
Forgot to make the new `shorthandCSS` option available to this Transformer too.

Added now, so you can do this:

```html
<style postcss>
  .padded {
    @apply py-2 px-4;
  }
</style>
```

... and, as long as you have `shorthandCSS: true` in your `config.js`, get this:

```html
<style>
  .padded {
    padding: 8px 16px;
  }
</style>
```

Of course if you have `shorthandCSS: false`, it will not merge the rules and you'll get:

```html
<style>
  .padded {
    padding-top: 8px;
    padding-bottom: 8px;
    padding-left: 8px;
    padding-right: 8px;
  }
</style>
```
