### PR TITLE
Don't add `undefined` to VML paths if `baseURL.url` is missing

### DIFF
--- a/src/transformers/baseUrl.js
+++ b/src/transformers/baseUrl.js
@@ -19,9 +19,9 @@ module.exports = async (html, config = {}, direct = false) => {
       .then(result => result.html)
   }
 
-  // Handle `baseUrl` as an object
+  // Handle `baseURL` as an object
   if (isObject(url) && !isEmpty(url)) {
-    html = rewriteVMLs(html, url.url)
+    html = rewriteVMLs(html, get(url, 'url', ''))
 
     return posthtml([baseUrl(url)]).process(html, posthtmlOptions).then(result => result.html)
   }

--- a/src/transformers/baseUrl.js
+++ b/src/transformers/baseUrl.js
@@ -5,7 +5,7 @@ const {get, merge, isObject, isEmpty} = require('lodash')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
-  const url = direct ? config : get(config, 'baseURL')
+  const url = direct ? config : get(config, 'baseURL', get(config, 'baseUrl'))
   const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
 
   // Handle `baseUrl` as a string


### PR DESCRIPTION
This PR fixes an issue where the string `undefined` was being prepended to VML src paths if you were using object syntax for `baseURL`, but somehow forgot to include the `url` key. This wasn't an issue for the rest of the markup, just when VML code was processed, so this makes the behavior consistent.

Also, `baseUrl` will also work now, just in case you were tired and made a typo :)