### PR TITLE
feat: support cjs extension for config

### DIFF
--- a/src/generators/config.js
+++ b/src/generators/config.js
@@ -13,16 +13,23 @@ module.exports = {
 
     const cwd = env === 'maizzle-ci' ? './test/stubs/config' : process.cwd()
 
-    for (const module of ['./config', './config.local']) {
+    for (const module of ['./config', './config.cjs', './config.local', './config.local.cjs']) {
       try {
         baseConfig = merge(baseConfig, requireUncached(path.resolve(cwd, module)))
       } catch {}
     }
 
     if (typeof env === 'string' && env !== 'local') {
-      try {
-        envConfig = merge(envConfig, requireUncached(path.resolve(cwd, `./config.${env}`)))
-      } catch {
+      let loaded = false
+      for (const module of [`./config.${env}`, `./config.${env}.cjs`]) {
+        try {
+          envConfig = merge(envConfig, requireUncached(path.resolve(cwd, module)))
+          loaded = true
+          break
+        } catch {}
+      }
+
+      if (!loaded) {
         throw new Error(`could not load config.${env}.js`)
       }
     }


### PR DESCRIPTION
When using Maizzle in a project with "type": "module", the configuration file `config.js` is treated like an ESM module, which causes an error (since it's written in CommonJS). To fix this, it should be renamed to `config.cjs`, but it doesn't seem like Maizzle supports this just yet (since it relies on Node's auto-extension resolution algorithm, which doesn't work for the `.cjs` extension).

This PR just adds some explicit checks for `.cjs` files in the configuration loader so that Maizzle correctly loads configuration files that end with a `.cjs` extension.

Let me know if you have any questions!