### PR TITLE
fix: baseURL defaults when configured as object

### DIFF
--- a/src/transformers/baseUrl.js
+++ b/src/transformers/baseUrl.js
@@ -7,13 +7,18 @@ const defaultConfig = require('../generators/posthtml/defaultConfig')
 module.exports = async (html, config = {}, direct = false) => {
   const url = direct ? config : get(config, 'baseURL', get(config, 'baseUrl'))
   const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
+  const defaultOptions = {
+    allTags: true,
+    styleTag: true,
+    inlineCss: true
+  }
 
   // Handle `baseUrl` as a string
   if (typeof url === 'string' && url.length > 0) {
     html = rewriteVMLs(html, url)
 
     return posthtml([
-      baseUrl({url, allTags: true, styleTag: true, inlineCss: true})
+      baseUrl({url, ...defaultOptions})
     ])
       .process(html, posthtmlOptions)
       .then(result => result.html)
@@ -23,7 +28,11 @@ module.exports = async (html, config = {}, direct = false) => {
   if (isObject(url) && !isEmpty(url)) {
     html = rewriteVMLs(html, get(url, 'url', ''))
 
-    return posthtml([baseUrl(url)]).process(html, posthtmlOptions).then(result => result.html)
+    return posthtml([
+      baseUrl(merge(defaultOptions, url))
+    ])
+      .process(html, posthtmlOptions)
+      .then(result => result.html)
   }
 
   return html

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -245,10 +245,7 @@ test('base URL (string)', async t => {
 test('base URL (object)', async t => {
   const source = await fixture('base-url')
   const html = await Maizzle.applyBaseUrl(source, {
-    url: 'https://example.com/',
-    allTags: true,
-    styleTag: true,
-    inlineCss: true
+    url: 'https://example.com/'
   })
 
   t.is(html, await expected('base-url'))


### PR DESCRIPTION
This PR fixes an issue with `baseURL` defaults when it is configured as an object.

Specifically, in this case the `url` was not being appended to `<style>` tags or inline CSS, you had to enable them manually, i.e.:

```js
baseURL: {
  url: 'https://example.com/images/',
  tags: ['img', 'source'],
  inlineCss: true,
  styleTag: true,
},
```

Now you can just do this and it will work:

```js
baseURL: {
  url: 'https://example.com/images/',
  tags: ['img', 'source']
},
```


