### PR TITLE
fix: templates source error

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -32,6 +32,11 @@ module.exports = async (env, spinner, config) => {
 
   // Parse each template config object
   await asyncForEach(templatesConfig, async templateConfig => {
+    if (!templateConfig) {
+      const configFileName = env === 'local' ? 'config.js' : `config.${env}.js`
+      throw new Error(`No template sources defined in \`build.templates\`, check your ${configFileName} file`)
+    }
+
     const outputDir = get(templateConfig, 'destination.path', `build_${env}`)
 
     await fs.remove(outputDir)

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -389,7 +389,13 @@ test('local server does not compile unwanted file types', async t => {
 test('throws if it cannot spin up local development server', async t => {
   await t.throwsAsync(async () => {
     await Maizzle.serve('local', {})
-  }, {instanceOf: TypeError})
+  }, {instanceOf: Error})
+})
+
+test('`templates.source` undefined', async t => {
+  await t.throwsAsync(async () => {
+    await Maizzle.build('maizzle-ci')
+  }, {instanceOf: Error})
 })
 
 test('`templates.source` defined as function (string paths)', async t => {


### PR DESCRIPTION
This makes the build error message less confusing when you didn't have a `build.templates.source` defined in the config.

So if you ran `maizzle build imaginary` but had no `config.imaginary.js`, you would have seen this cryptic message:

```
$ maizzle build imaginary
✖ Cannot read properties of undefined (reading 'source')
```

Now you'll get a better error message:

```
$ maizzle build imaginary
✖ No template sources defined in `build.templates`, check your config.imaginary.js file
```
