### PR TITLE
Update current file information when developing locally

### DIFF
--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -81,16 +81,21 @@ const serve = async (env = 'local', config = {}) => {
 
         spinner.start('Building email...')
 
-        file = file.replace(/\\/g, '/')
-
-        const renderOptions = {
-          maizzle: config,
-          ...config.events
-        }
-
         renderToString(
-          await fs.readFile(file, 'utf8'),
-          renderOptions
+          await fs.readFile(file.replace(/\\/g, '/'), 'utf8'),
+          {
+            maizzle: merge(
+              config,
+              {
+                build: {
+                  current: {
+                    path: path.parse(file)
+                  }
+                }
+              }
+            ),
+            ...config.events
+          }
         )
           .then(async ({html, config}) => {
             let source = ''


### PR DESCRIPTION
Fixed an issue where information about the [current template](https://maizzle.com/docs/templates#current-template) was not being updated when developing locally (part of #885).