### PR TITLE
Use native `for await` instead of custom asyncForEach method

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,9 +1,4 @@
 module.exports = {
-  asyncForEach: async (array, callback) => {
-    for (let index = 0; index < array.length; index++) {
-      await callback(array[index], index, array) // eslint-disable-line
-    }
-  },
   requireUncached: module => {
     try {
       delete require.cache[require.resolve(module)]


### PR DESCRIPTION
This PR changes replaces the custom `asyncForEach` method that we used to iterate over arrays asynchronously with the native `for await...of` statement.
