### PR TITLE
Fix TailwindCSS content paths

### DIFF
--- a/src/generators/posthtml/defaultComponentsConfig.js
+++ b/src/generators/posthtml/defaultComponentsConfig.js
@@ -1,0 +1,9 @@
+module.exports = {
+  root: './',
+  folders: ['src/components', 'src/layouts', 'src/templates'],
+  fileExtension: 'html',
+  tag: 'component',
+  attribute: 'src',
+  yield: 'content',
+  propsAttribute: 'locals'
+}

--- a/src/generators/posthtml/index.js
+++ b/src/generators/posthtml/index.js
@@ -5,6 +5,7 @@ const fetch = require('posthtml-fetch')
 const layouts = require('posthtml-extend')
 const components = require('posthtml-component')
 const defaultConfig = require('./defaultConfig')
+const defaultComponentsConfig = require('./defaultComponentsConfig')
 
 module.exports = async (html, config) => {
   const layoutsOptions = get(config, 'build.layouts', {})
@@ -35,6 +36,20 @@ module.exports = async (html, config) => {
     )
   )
 
+  const defaultComponentsOptions = merge(
+    defaultComponentsConfig,
+    {
+      folders: [
+        ...defaultComponentsConfig.folders,
+        ...get(componentsOptions, 'folders', [])
+      ]
+    },
+    {
+      root: componentsOptions.root || './',
+      expressions: {...expressionsOptions, locals}
+    }
+  )
+
   return posthtml([
     fetchPlugin,
     layouts(
@@ -48,15 +63,7 @@ module.exports = async (html, config) => {
     ),
     components(
       merge(
-        {
-          root: componentsOptions.root || './',
-          folders: ['src/components', 'src/layouts', 'src/templates'],
-          tag: 'component',
-          attribute: 'src',
-          yield: 'content',
-          propsAttribute: 'locals',
-          expressions: {...expressionsOptions, locals}
-        },
+        defaultComponentsOptions,
         componentsOptions
       )
     ),

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -62,8 +62,7 @@ module.exports = {
       content: {
         files: [
           layoutsPath,
-          componentsPath,
-          {raw: html, extension: 'html'}
+          componentsPath
         ]
       }
     }, userConfig(config))
@@ -74,10 +73,14 @@ module.exports = {
         files: [
           layoutsPath,
           componentsPath,
-          ...tailwindConfig.content,
-          {raw: html, extension: 'html'}
+          ...tailwindConfig.content
         ]
       }
+    }
+
+    // Add raw HTML if using API
+    if (html) {
+      tailwindConfig.content.files.push({raw: html, extension: 'html'})
     }
 
     // Include all `build.templates.source` paths when scanning for selectors to preserve

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -7,6 +7,7 @@ const postcssNested = require('tailwindcss/nesting')
 const {requireUncached} = require('../utils/helpers')
 const mergeLonghand = require('postcss-merge-longhand')
 const {get, isObject, isEmpty, merge} = require('lodash')
+const defaultComponentsConfig = require('./posthtml/defaultComponentsConfig')
 
 const addImportantPlugin = () => {
   return {
@@ -48,21 +49,24 @@ module.exports = {
 
     // Merge user's Tailwind config on top of a 'base' config
     const layoutsRoot = get(config, 'build.layouts.root')
-    const componentsRoot = get(config, 'build.components.root')
+    const componentsRoot = get(config, 'build.components.root', defaultComponentsConfig.root)
 
     const layoutsPath = typeof layoutsRoot === 'string' && layoutsRoot ?
-      `${layoutsRoot}/**/*.html`.replace(/\/\//g, '/') :
-      './src/layouts/**/*.html'
+      `${layoutsRoot}/**/*.*`.replace(/\/\//g, '/') :
+      'src/layouts/**/*.*'
 
-    const componentsPath = typeof componentsRoot === 'string' && componentsRoot ?
-      `${componentsRoot}/**/*.html`.replace(/\/\//g, '/') :
-      './src/components/**/*.html'
+    const componentsPath = defaultComponentsConfig.folders.map(folder => {
+      return path
+        .join(componentsRoot, folder, `**/*.${defaultComponentsConfig.fileExtension}`)
+        .replace(/\\/g, '/')
+        .replace(/\/\//g, '/')
+    })
 
     const tailwindConfig = merge({
       content: {
         files: [
-          layoutsPath,
-          componentsPath
+          ...componentsPath,
+          layoutsPath
         ]
       }
     }, userConfig(config))
@@ -71,8 +75,8 @@ module.exports = {
     if (Array.isArray(tailwindConfig.content)) {
       tailwindConfig.content = {
         files: [
+          ...componentsPath,
           layoutsPath,
-          componentsPath,
           ...tailwindConfig.content
         ]
       }
@@ -88,34 +92,35 @@ module.exports = {
 
     if (buildTemplates) {
       const templateObjects = Array.isArray(buildTemplates) ? buildTemplates : [buildTemplates]
-      const templateSources = templateObjects.map(template => {
+      const fileTypes = get(buildTemplates, 'filetypes', 'html')
+
+      templateObjects.forEach(template => {
         const source = get(template, 'source')
 
         if (typeof source === 'function') {
           const sources = source(config)
 
           if (Array.isArray(sources)) {
-            sources.map(s => tailwindConfig.content.files.push(s))
+            sources.map(s => tailwindConfig.content.files.push(`${s}/**/*.${fileTypes}`))
           } else if (typeof sources === 'string') {
             tailwindConfig.content.files.push(sources)
           }
-
-          // Must return a valid `content` entry
-          return {raw: '', extension: 'html'}
         }
 
         // Support single-file sources i.e. src/templates/index.html
-        if (typeof source === 'string' && Boolean(path.extname(source))) {
+        else if (typeof source === 'string' && Boolean(path.extname(source))) {
           tailwindConfig.content.files.push(source)
-
-          return {raw: '', extension: 'html'}
         }
 
-        return `${source}/**/*.*`
+        // Default behavior - directory sources as a string
+        else {
+          tailwindConfig.content.files.push(`${source}/**/*.${fileTypes}`)
+        }
       })
-
-      tailwindConfig.content.files.push(...templateSources)
     }
+
+    // Filter out any duplicate content paths
+    tailwindConfig.content.files = [...new Set(tailwindConfig.content.files)]
 
     const userFilePath = get(config, 'build.tailwind.css', path.join(process.cwd(), 'src/css/tailwind.css'))
     const userFileExists = await fs.pathExists(userFilePath)

--- a/test/test-posthtml.js
+++ b/test/test-posthtml.js
@@ -50,7 +50,55 @@ template: second
     Child in second.html`)
 })
 
-test('components', async t => {
+test('components (legacy)', async t => {
+  const source = await fixture('components/backwards-compatibility')
+
+  const options = {
+    maizzle: {
+      env: 'maizzle-ci',
+      build: {
+        posthtml: {
+          expressions: {
+            delimiters: ['[[', ']]']
+          }
+        }
+      }
+    }
+  }
+
+  const html = await renderString(source, options)
+
+  t.is(html.replace(/\n+/g, '\n').trim(), await expected('components/backwards-compatibility'))
+})
+
+test('fetch component', async t => {
+  const source = `<extends src="test/stubs/layouts/legacy.html">
+    <block name="template">
+      <fetch url="test/stubs/data.json">
+        <each loop="user in response">[[ user.name + (loop.last ? '' : ', ') ]]</each>
+      </fetch>
+    </block>
+  </extends>`
+
+  const options = {
+    maizzle: {
+      env: 'maizzle-ci',
+      build: {
+        posthtml: {
+          expressions: {
+            delimiters: ['[[', ']]']
+          }
+        }
+      }
+    }
+  }
+
+  const html = await renderString(source, options)
+
+  t.is(html.trim(), 'Leanne Graham, Ervin Howell, Clementine Bauch')
+})
+
+test.serial('components', async t => {
   const source = await fixture('components/kitchen-sink')
 
   const options = {
@@ -75,52 +123,4 @@ test('components', async t => {
     await prettify(html, {ocd: true}),
     await expected('components/kitchen-sink')
   )
-})
-
-test('components (legacy)', async t => {
-  const source = await fixture('components/backwards-compatibility')
-
-  const options = {
-    maizzle: {
-      env: 'maizzle-ci',
-      build: {
-        posthtml: {
-          expressions: {
-            delimiters: ['[[', ']]']
-          }
-        }
-      }
-    }
-  }
-
-  const html = await renderString(source, options)
-
-  t.is(html.replace(/\n+/g, '\n').trim(), await expected('components/backwards-compatibility'))
-})
-
-test('fetch component', async t => {
-  const source = `<extends src="test/stubs/layouts/legacy.html">
-  <block name="template">
-    <fetch url="test/stubs/data.json">
-      <each loop="user in response">[[ user.name + (loop.last ? '' : ', ') ]]</each>
-    </fetch>
-  </block>
-</extends>`
-
-  const options = {
-    maizzle: {
-      env: 'maizzle-ci',
-      build: {
-        posthtml: {
-          expressions: {
-            delimiters: ['[[', ']]']
-          }
-        }
-      }
-    }
-  }
-
-  const html = await renderString(source, options)
-
-  t.is(html.trim(), 'Leanne Graham, Ervin Howell, Clementine Bauch')
 })

--- a/test/test-tailwindcss.js
+++ b/test/test-tailwindcss.js
@@ -166,25 +166,6 @@ test('works with custom `layouts.root`', async t => {
   t.true(css.includes('.bg-red-500'))
 })
 
-test('works with custom `components.root`', async t => {
-  const css = await Tailwind.compile({
-    config: {
-      build: {
-        components: {
-          root: './test/stubs/components'
-        },
-        tailwind: {
-          config: {
-            content: ['./test/stubs/tailwind/*.html']
-          }
-        }
-      }
-    }
-  })
-
-  t.true(css.includes('.flex'))
-})
-
 test('adds `!important` to selectors that will not be inlined', async t => {
   const css = await Tailwind.compile({
     config: {

--- a/test/test-tostring.js
+++ b/test/test-tostring.js
@@ -88,7 +88,7 @@ test('locals work when defined in all supported places', async t => {
   t.is(result, `1, 2, 3, undefined`)
 })
 
-test('prevents overwriting page object', async t => {
+test.serial('prevents overwriting page object', async t => {
   const result = await renderString(`{{ page.one }}, {{ two }}, {{ three }}, {{ inline }}`, {
     maizzle: {
       one: 1,

--- a/xo.config.js
+++ b/xo.config.js
@@ -4,6 +4,7 @@ module.exports = {
     semi: 0,
     complexity: 0,
     'max-params': 0,
+    'brace-style': 0,
     'no-lonely-if': 0,
     'unicorn/no-reduce': 0,
     'import/extensions': 0,


### PR DESCRIPTION
This PR:

- fixes an issue where utilities in Templates inside directories with dots in their name (like `src/templates/test.com`) were not being generated
- adds `{raw: html, extension: 'html'}` to Tailwind's `content.files` only if `html` was passed to the Tailwind compiler - this happens/is needed only when using Maizzle programmatically, so we removed it for normal use cases
