### PR TITLE
fix: default components options

### DIFF
--- a/src/generators/posthtml/index.js
+++ b/src/generators/posthtml/index.js
@@ -37,16 +37,16 @@ module.exports = async (html, config) => {
   )
 
   const defaultComponentsOptions = merge(
-    defaultComponentsConfig,
     {
+      ...defaultComponentsConfig,
       folders: [
         ...defaultComponentsConfig.folders,
         ...get(componentsOptions, 'folders', [])
-      ]
+      ],
+      expressions: {...expressionsOptions, locals}
     },
     {
-      root: componentsOptions.root || './',
-      expressions: {...expressionsOptions, locals}
+      root: componentsOptions.root || './'
     }
   )
 


### PR DESCRIPTION
This PR fixes an issue with the default Components options that was causing props data mismatching, resulting in props not using the defaults they were set to.
