### PR TITLE
Preserve safelisted selectors when inlining CSS

### DIFF
--- a/src/transformers/removeInlinedSelectors.js
+++ b/src/transformers/removeInlinedSelectors.js
@@ -6,7 +6,7 @@ const matchHelper = require('posthtml-match-helper')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}) => {
-  if (get(config, 'removeInlinedClasses') === false) {
+  if (get(config, 'removeInlinedSelectors') === false) {
     return html
   }
 

--- a/src/transformers/removeInlinedSelectors.js
+++ b/src/transformers/removeInlinedSelectors.js
@@ -10,12 +10,15 @@ module.exports = async (html, config = {}) => {
     return html
   }
 
-  const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))
+  const options = {
+    posthtml: merge(defaultConfig, get(config, 'build.posthtml.options', {})),
+    removeUnusedCSS: config
+  }
 
-  return posthtml([plugin(posthtmlOptions)]).process(html, posthtmlOptions).then(result => result.html)
+  return posthtml([plugin(options)]).process(html, options.posthtml).then(result => result.html)
 }
 
-const plugin = posthtmlOptions => tree => {
+const plugin = (options = {}) => tree => {
   const process = node => {
     // For each style tag...
     if (node.tag === 'style') {
@@ -41,8 +44,16 @@ const plugin = posthtmlOptions => tree => {
         }
 
         try {
+          const safelist = get(options.removeUnusedCSS, 'whitelist', [])
+
           // If we find the selector in the HTML...
           tree.match(matchHelper(selector), n => {
+            // If the selector is safelisted, preserve it
+            if (safelist.some(item => item.endsWith(selector) || item.startsWith(selector))) {
+              preservedClasses.push(selector)
+              return n
+            }
+
             const parsedAttrs = parseAttrs(n.attrs)
             const classAttr = get(parsedAttrs, 'class', [])
             const styleAttr = get(parsedAttrs, 'style', {})
@@ -64,7 +75,7 @@ const plugin = posthtmlOptions => tree => {
 
             // Fix issue with .compose() automatically quoting attributes with no values
             Object.entries(n.attrs).forEach(([name, value]) => {
-              if (value === '' && get(posthtmlOptions, 'recognizeNoValueAttribute') === true) {
+              if (value === '' && get(options.posthtml, 'recognizeNoValueAttribute') === true) {
                 n.attrs[name] = true
               }
             })

--- a/src/transformers/removeUnusedCss.js
+++ b/src/transformers/removeUnusedCss.js
@@ -36,7 +36,7 @@ module.exports = async (html, config = {}, direct = false) => {
     whitelist: [...get(config, 'whitelist', []), ...safelist]
   }
 
-  const options = merge(defaultOptions, get(config, 'removeUnusedCSS', {}))
+  const options = merge(defaultOptions, config)
 
   /**
    * Remove possibly inlined selectors, as long as we're not calling

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -615,21 +615,11 @@ test('remove inlined selectors (disabled)', async t => {
     </body>
   </html>`
 
-  const expected = `<!DOCTYPE html>
-  <html>
-    <head>
-      <style>
-        .remove {color: red}
-      </style>
-    </head>
-    <body>
-      <div class="remove" style="color: red"></div>
-    </body>
-  </html>`
+  const withRemoveUnusedCSS = await Maizzle.removeUnusedCSS(html, {removeInlinedClasses: false})
+  const withRemoveInlinedSelectors = await Maizzle.removeInlinedClasses(html, {removeInlinedClasses: false})
 
-  const result = await Maizzle.removeInlinedClasses(html, {removeInlinedClasses: false})
-
-  t.is(result, expected)
+  t.is(withRemoveUnusedCSS, html)
+  t.is(withRemoveInlinedSelectors, html)
 })
 
 test('shorthand inline css', async t => {

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -584,8 +584,19 @@ test('remove inlined selectors', async t => {
     </body>
   </html>`
 
+  const safelisted = `<!DOCTYPE html>
+  <html>
+    <head><style>.preserve-me {
+          color: red;
+        }</style></head>
+    <body>
+      <div class="preserve-me" style="color: red"></div>
+    </body>
+  </html>`
+
   const basic = await Maizzle.removeInlinedClasses(html)
   const noEmptyStyle = await Maizzle.removeInlinedClasses(html2)
+  const safelistedHTML = await Maizzle.removeInlinedClasses(safelisted, {whitelist: ['.preserve-me']})
 
   const withPostHTMLOptions = await Maizzle.removeInlinedClasses(html, {
     build: {
@@ -600,6 +611,7 @@ test('remove inlined selectors', async t => {
   t.is(basic, expectedHTML)
   t.is(withPostHTMLOptions, expectedHTML)
   t.is(noEmptyStyle, expectedNoEmptyStyleTags)
+  t.is(safelistedHTML, safelisted)
 })
 
 test('remove inlined selectors (disabled)', async t => {


### PR DESCRIPTION
### Fixed

- fixed an issue where selectors that were safelisted with `removeUnusedCSS.whitelist` were still being removed after they were inlined
- fixed an issue where `removeInlinedSelectors` could not be disabled