### PR TITLE
refactor: allow overriding email comb selector safelist

### DIFF
--- a/src/transformers/removeUnusedCss.js
+++ b/src/transformers/removeUnusedCss.js
@@ -33,7 +33,7 @@ module.exports = async (html, config = {}, direct = false) => {
       {heads: '{{', tails: '}}'},
       {heads: '{%', tails: '%}'}
     ],
-    whitelist: [...get(config, 'whitelist', []), ...safelist]
+    whitelist: get(config, 'whitelist', safelist)
   }
 
   const options = merge(defaultOptions, config)


### PR DESCRIPTION
This PR changes the way `removeUnusedCSS` behaves, allowing you to completely override its selectors safelist from your `config.js`. This was necessary so that email client targeting selectors do not show up in all of your project's templates when you just want to use a one-off. They would normally show up because Tailwind CSS is compiled once for all templates, and then is purged on a template-basis.

Maizzle won't remove these selectors in the first pass, but with this change you can now run a quick second pass to remove unnecessary client targeting selectors from templates that don't need them:

```js
// config.production.js

const {removeUnusedCSS} = require('@maizzle/framework')

module.exports = {
  // ...
  events: {
	// Run removeUnusedCSS again, this time overriding the `whitelist` option so that no email client targeting selector is preserved
    afterTransformers(html) {
      return removeUnusedCSS(html, {
        whitelist: [],
      })
    }
  }
}
```