### PR TITLE
Defaults for running `safeClassNames`

### DIFF
--- a/src/transformers/filters/index.js
+++ b/src/transformers/filters/index.js
@@ -41,7 +41,11 @@ module.exports = async (html, config = {}, direct = false) => {
     posthtmlContent(filters)
   ]
 
-  if (get(config, 'safeClassNames') !== false) {
+  /**
+   * Run `safeClassNames` in filters only when not when developing locally and
+   * `safeClassNames` is not explicitly disabled (set to `false`).
+   */
+  if (get(config, 'env') !== 'local' && get(config, 'safeClassNames') !== false) {
     posthtmlPlugins.push(safeClassNames({
       replacements: {
         '{': '{',

--- a/src/transformers/safeClassNames.js
+++ b/src/transformers/safeClassNames.js
@@ -7,13 +7,14 @@ module.exports = async (html, config = {}, direct = false) => {
   /*
    * Don't run when:
    * - `config` is falsy or empty
-   * - developing locally and `safeClassNames` is not explicitly
-   *   set to `true`
+   * - developing locally and `safeClassNames` is not explicitly `true`
+   * - `safeClassNames` is explicitly `false`
    */
   if (
     !config
     || isEmpty(config)
     || (get(config, 'env') === 'local' && get(config, 'safeClassNames') !== true)
+    || get(config, 'safeClassNames') === false
   ) {
     return html
   }

--- a/src/transformers/safeClassNames.js
+++ b/src/transformers/safeClassNames.js
@@ -1,20 +1,20 @@
 const posthtml = require('posthtml')
-const {get, merge} = require('lodash')
+const {get, merge, isEmpty} = require('lodash')
 const safeClassNames = require('posthtml-safe-class-names')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {
-  const option = get(config, 'safeClassNames')
-
-  if (option === false) {
-    return html
-  }
-
   /*
-   * Setting it to `true` in the config will run `safeClassNames`
-   * no matter the environment.
+   * Don't run when:
+   * - `config` is falsy or empty
+   * - developing locally and `safeClassNames` is not explicitly
+   *   set to `true`
    */
-  if (config.env === 'local' && !option) {
+  if (
+    !config
+    || isEmpty(config)
+    || (get(config, 'env') === 'local' && get(config, 'safeClassNames') !== true)
+  ) {
     return html
   }
 

--- a/test/test-transformers.js
+++ b/test/test-transformers.js
@@ -284,7 +284,7 @@ test('safe class names', async t => {
 })
 
 test('safe class names (disabled)', async t => {
-  const html = await Maizzle.safeClassNames('<div class="sm:text-left">foo</div>', {safeClassNames: false})
+  const html = await Maizzle.safeClassNames('<div class="sm:text-left">foo</div>')
 
   t.is(html, '<div class="sm:text-left">foo</div>')
 })


### PR DESCRIPTION
This PR changes the way the `safeClassNames` Transformer runs by default.

It now:

- doesn't run when `env` is `local` (developing locally, like with `maizzle serve`)
	- exception: will run locally if explicitly set to `true`
- doesn't run if explicitly disabled (`safeClassNames: false`)

This makes it a little easier to debug when developing locally and inspecting the code - by default now you get to see the Tailwind classes exactly as you wrote them.