### PR TITLE
Fix using local Tailwind config in style filter

### DIFF
--- a/src/transformers/filters/index.js
+++ b/src/transformers/filters/index.js
@@ -30,7 +30,7 @@ module.exports = async (html, config = {}, direct = false) => {
     config: merge({
       build: {
         tailwind: {
-          config: get(config, 'build.tailwind.config', {})
+          config: get(config, 'build.tailwind.config', 'tailwind.config.js')
         }
       }
     }, maizzleConfig)


### PR DESCRIPTION
This PR fixes an issue where the default (web) Tailwind config was used inside `<style tailwindcss>`, instead of the local `tailwind.config.js`.