### PR TITLE
refactor: prefer role none over presentation

### DIFF
--- a/src/transformers/extraAttributes.js
+++ b/src/transformers/extraAttributes.js
@@ -14,14 +14,20 @@ module.exports = async (html, config = {}, direct = false) => {
     table: {
       cellpadding: 0,
       cellspacing: 0,
-      role: 'presentation'
+      role: 'none'
     },
     img: {
       alt: ''
     }
   }
 
-  attributes = direct ? {...attributes, ...config} : (isObject(config.extraAttributes) ? {...attributes, ...config.extraAttributes} : attributes)
+  attributes = direct
+    ? {...attributes, ...config}
+    : (
+      isObject(config.extraAttributes)
+        ? {...attributes, ...config.extraAttributes}
+        : attributes
+    )
 
   return posthtml([addAttributes({attributes})]).process(html, posthtmlOptions).then(result => result.html)
 }


### PR DESCRIPTION
This changes the default `role` attribute value added to `<table>` elements from `presentation` to `none`, as it does the same thing and is 8 characters shorter, resulting in a smaller HTML size.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/none_role):

> The `none` role is a synonym for the [presentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/presentation_role) role; they both remove an element's implicit ARIA semantics from being exposed to the accessibility tree.
