### PR TITLE
feat: expose config in afterBuild event

### DIFF
--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -233,7 +233,7 @@ module.exports = async (env, spinner, config) => {
   }
 
   if (config.events && typeof config.events.afterBuild === 'function') {
-    await config.events.afterBuild(files)
+    await config.events.afterBuild(files, config)
   }
 
   return {


### PR DESCRIPTION
This PR exposes the `config` object as the second parameter of the `afterBuild` event function, so you can read it like this:

```js
// config.production.js
module.exports = {
  // ...
  events: {
    afterBuild(files, config) {
      const env = config.env

	  // do stuff with env
	}
  }
}
```

