### PR TITLE
fix: object merging

### DIFF
--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -6,8 +6,8 @@ const Config = require('../generators/config')
 const buildToFile = require('../commands/build')
 const renderToString = require('../functions/render')
 
-const {get, merge, isObject} = require('lodash')
-const {clearConsole} = require('../utils/helpers')
+const {get, isObject} = require('lodash')
+const {clearConsole, merge} = require('../utils/helpers')
 
 /**
  * Initialize Browsersync on-demand

--- a/src/generators/config.js
+++ b/src/generators/config.js
@@ -1,6 +1,5 @@
 const path = require('path')
-const {merge} = require('lodash')
-const {requireUncached} = require('../utils/helpers')
+const {merge, requireUncached} = require('../utils/helpers')
 
 module.exports = {
   getMerged: async (env = 'local') => {

--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -1,7 +1,8 @@
 const path = require('path')
 const fs = require('fs-extra')
 const glob = require('glob-promise')
-const {get, isEmpty, merge} = require('lodash')
+const {get, isEmpty} = require('lodash')
+const {merge} = require('../../utils/helpers')
 
 const Config = require('../config')
 const Tailwind = require('../tailwindcss')

--- a/src/generators/output/to-string.js
+++ b/src/generators/output/to-string.js
@@ -1,6 +1,7 @@
 const fm = require('front-matter')
-const {get, merge} = require('lodash')
+const {get} = require('lodash')
 const posthtml = require('../posthtml')
+const {merge} = require('../../utils/helpers')
 const Transformers = require('../../transformers')
 const Tailwind = require('../tailwindcss')
 const Config = require('../config')

--- a/src/generators/plaintext.js
+++ b/src/generators/plaintext.js
@@ -1,6 +1,7 @@
 const path = require('path')
+const {get} = require('lodash')
 const posthtml = require('posthtml')
-const {get, merge} = require('lodash')
+const {merge} = require('../utils/helpers')
 const {stripHtml} = require('string-strip-html')
 const defaultConfig = require('./posthtml/defaultConfig')
 

--- a/src/generators/tailwindcss.js
+++ b/src/generators/tailwindcss.js
@@ -3,10 +3,10 @@ const fs = require('fs-extra')
 const postcss = require('postcss')
 const tailwindcss = require('tailwindcss')
 const postcssImport = require('postcss-import')
+const {get, isObject, isEmpty} = require('lodash')
 const postcssNested = require('tailwindcss/nesting')
-const {requireUncached} = require('../utils/helpers')
+const {merge, requireUncached} = require('../utils/helpers')
 const mergeLonghand = require('postcss-merge-longhand')
-const {get, isObject, isEmpty, merge} = require('lodash')
 const defaultComponentsConfig = require('./posthtml/defaultComponentsConfig')
 
 const addImportantPlugin = () => {

--- a/src/transformers/attributeToStyle.js
+++ b/src/transformers/attributeToStyle.js
@@ -1,7 +1,8 @@
 const posthtml = require('posthtml')
+const {merge} = require('../utils/helpers')
 const parseAttrs = require('posthtml-attrs-parser')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
-const {get, merge, forEach, intersection, keys, isEmpty} = require('lodash')
+const {get, forEach, intersection, keys, isEmpty} = require('lodash')
 
 module.exports = async (html, config = {}, direct = false) => {
   const posthtmlOptions = merge(defaultConfig, get(config, 'build.posthtml.options', {}))

--- a/src/transformers/baseUrl.js
+++ b/src/transformers/baseUrl.js
@@ -1,7 +1,8 @@
 const posthtml = require('posthtml')
 const isUrl = require('is-url-superb')
+const {merge} = require('../utils/helpers')
 const baseUrl = require('posthtml-base-url')
-const {get, merge, isObject, isEmpty} = require('lodash')
+const {get, isObject, isEmpty} = require('lodash')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {

--- a/src/transformers/extraAttributes.js
+++ b/src/transformers/extraAttributes.js
@@ -1,5 +1,6 @@
 const posthtml = require('posthtml')
-const {get, merge, isObject} = require('lodash')
+const {get, isObject} = require('lodash')
+const {merge} = require('../utils/helpers')
 const addAttributes = require('posthtml-extra-attributes')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 

--- a/src/transformers/filters/index.js
+++ b/src/transformers/filters/index.js
@@ -1,5 +1,6 @@
 const posthtml = require('posthtml')
-const {get, omit, has, merge} = require('lodash')
+const {get, omit, has} = require('lodash')
+const {merge} = require('../../utils/helpers')
 const defaultFilters = require('./defaultFilters')
 const PostCSS = require('../../generators/postcss')
 const posthtmlContent = require('posthtml-content')

--- a/src/transformers/markdown.js
+++ b/src/transformers/markdown.js
@@ -1,5 +1,6 @@
+const {get} = require('lodash')
 const posthtml = require('posthtml')
-const {get, merge} = require('lodash')
+const {merge} = require('../utils/helpers')
 const markdown = require('posthtml-markdownit')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 

--- a/src/transformers/posthtmlMso.js
+++ b/src/transformers/posthtmlMso.js
@@ -1,6 +1,7 @@
+const {get} = require('lodash')
 const posthtml = require('posthtml')
-const {get, merge} = require('lodash')
 const outlook = require('posthtml-mso')
+const {merge} = require('../utils/helpers')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config) => {

--- a/src/transformers/prettify.js
+++ b/src/transformers/prettify.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 const pretty = require('pretty')
-const {get, merge, isEmpty, isObject} = require('lodash')
+const {merge} = require('../utils/helpers')
+const {get, isEmpty, isObject} = require('lodash')
 
 module.exports = async (html, config = {}, direct = false) => {
   const defaultConfig = {

--- a/src/transformers/preventWidows.js
+++ b/src/transformers/preventWidows.js
@@ -1,5 +1,6 @@
 const posthtml = require('posthtml')
-const {get, merge, isEmpty} = require('lodash')
+const {get, isEmpty} = require('lodash')
+const {merge} = require('../utils/helpers')
 const {removeWidows} = require('string-remove-widows')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 

--- a/src/transformers/removeAttributes.js
+++ b/src/transformers/removeAttributes.js
@@ -1,5 +1,6 @@
+const {get} = require('lodash')
 const posthtml = require('posthtml')
-const {get, merge} = require('lodash')
+const {merge} = require('../utils/helpers')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {

--- a/src/transformers/removeInlineBackgroundColor.js
+++ b/src/transformers/removeInlineBackgroundColor.js
@@ -1,7 +1,7 @@
 const posthtml = require('posthtml')
-const {get, merge, isEmpty} = require('lodash')
+const {get, isEmpty} = require('lodash')
 const parseAttrs = require('posthtml-attrs-parser')
-const {toStyleString} = require('../utils/helpers')
+const {merge, toStyleString} = require('../utils/helpers')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {

--- a/src/transformers/removeInlineSizes.js
+++ b/src/transformers/removeInlineSizes.js
@@ -1,7 +1,7 @@
 const posthtml = require('posthtml')
-const {get, merge, isEmpty} = require('lodash')
+const {get, isEmpty} = require('lodash')
 const parseAttrs = require('posthtml-attrs-parser')
-const {toStyleString} = require('../utils/helpers')
+const {merge, toStyleString} = require('../utils/helpers')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 
 module.exports = async (html, config = {}, direct = false) => {

--- a/src/transformers/removeInlinedSelectors.js
+++ b/src/transformers/removeInlinedSelectors.js
@@ -1,6 +1,7 @@
 const postcss = require('postcss')
 const posthtml = require('posthtml')
-const {get, merge, has, remove} = require('lodash')
+const {merge} = require('../utils/helpers')
+const {get, has, remove} = require('lodash')
 const parseAttrs = require('posthtml-attrs-parser')
 const matchHelper = require('posthtml-match-helper')
 const defaultConfig = require('../generators/posthtml/defaultConfig')

--- a/src/transformers/removeUnusedCss.js
+++ b/src/transformers/removeUnusedCss.js
@@ -1,5 +1,6 @@
 const {comb} = require('email-comb')
-const {get, merge, isEmpty, isObject} = require('lodash')
+const {merge} = require('../utils/helpers')
+const {get, isEmpty, isObject} = require('lodash')
 const removeInlinedClasses = require('./removeInlinedSelectors')
 
 module.exports = async (html, config = {}, direct = false) => {

--- a/src/transformers/safeClassNames.js
+++ b/src/transformers/safeClassNames.js
@@ -1,5 +1,6 @@
 const posthtml = require('posthtml')
-const {get, merge, isEmpty} = require('lodash')
+const {get, isEmpty} = require('lodash')
+const {merge} = require('../utils/helpers')
 const safeClassNames = require('posthtml-safe-class-names')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 

--- a/src/transformers/shorthandInlineCSS.js
+++ b/src/transformers/shorthandInlineCSS.js
@@ -1,5 +1,6 @@
 const posthtml = require('posthtml')
-const {get, merge, isObject, isEmpty} = require('lodash')
+const {merge} = require('../utils/helpers')
+const {get, isObject, isEmpty} = require('lodash')
 const mergeInlineLonghand = require('posthtml-postcss-merge-longhand')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 

--- a/src/transformers/sixHex.js
+++ b/src/transformers/sixHex.js
@@ -1,5 +1,6 @@
+const {get} = require('lodash')
 const posthtml = require('posthtml')
-const {get, merge} = require('lodash')
+const {merge} = require('../utils/helpers')
 const {conv} = require('color-shorthand-hex-to-six-digit')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 

--- a/src/transformers/urlParameters.js
+++ b/src/transformers/urlParameters.js
@@ -1,5 +1,6 @@
 const posthtml = require('posthtml')
-const {get, merge, isEmpty} = require('lodash')
+const {get, isEmpty} = require('lodash')
+const {merge} = require('../utils/helpers')
 const urlParams = require('posthtml-url-parameters')
 const defaultConfig = require('../generators/posthtml/defaultConfig')
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,3 +1,5 @@
+const {mergeWith} = require('lodash')
+
 module.exports = {
   requireUncached: module => {
     try {
@@ -9,5 +11,24 @@ module.exports = {
   },
   // https://github.com/lukeed/console-clear
   clearConsole: () => process.stdout.write('\x1B[H\x1B[2J'),
-  toStyleString: (object = {}) => Object.entries(object).map(([k, v]) => `${k}: ${v}`).join('; ')
+  toStyleString: (object = {}) => Object.entries(object).map(([k, v]) => `${k}: ${v}`).join('; '),
+  merge: (...objects) => {
+    if (objects.length < 2) {
+      return objects[0]
+    }
+
+    let merged = {}
+
+    for (const object of objects) {
+      merged = mergeWith(merged, object, (existingValue, newValue) => {
+        if (Array.isArray(existingValue) && Array.isArray(newValue)) {
+          return [...existingValue, ...newValue]
+        }
+
+        return undefined
+      })
+    }
+
+    return merged
+  }
 }

--- a/test/test-misc.js
+++ b/test/test-misc.js
@@ -1,8 +1,29 @@
 const test = require('ava')
 const path = require('path')
-const {requireUncached} = require('../src/utils/helpers')
+const h = require('../src/utils/helpers')
 
 test('requires an uncached module', t => {
-  const helpers = requireUncached(path.resolve(process.cwd(), 'src/utils/helpers'))
+  const helpers = h.requireUncached(path.resolve(process.cwd(), 'src/utils/helpers'))
   t.is(typeof helpers.requireUncached, 'function')
+})
+
+test('merges multiple objects containing arrays', t => {
+  const object1 = {foo: 'bar', arr: [1, 2]}
+  const object2 = {arr: [3, 4], baz: 'qux'}
+  const object3 = {what: 'ever', arr: [5, 6]}
+  const merged = h.merge(object1, object2, object3)
+
+  t.deepEqual(merged, {
+    arr: [1, 2, 3, 4, 5, 6],
+    baz: 'qux',
+    foo: 'bar',
+    what: 'ever'
+  })
+})
+
+test('returns object when less than two objects are provided', t => {
+  const object = {arr: [1, 2]}
+  const merged = h.merge(object)
+
+  t.deepEqual(merged, object)
 })


### PR DESCRIPTION
Switched to using a custom function based on `lodash.mergeWith` instead of `lodash.merge`, to avoid overwriting array values when merging objects ([reference](https://github.com/lodash/lodash/issues/5384)). Fixes #1057.

Given this:

```js
merge(
  {foo: ["a", "b", "c"]},
  {foo: ["d"]}
)
```

Previously: 

```js
{
  foo: ["d", "b", "c"]
}
```

Now:

```js
{
  foo: ["a", "b", "c", "d"]
}
```

