### PR TITLE
fix: remove custom regexes in prettier output reformatting

### DIFF
--- a/src/transformers/prettify.js
+++ b/src/transformers/prettify.js
@@ -32,10 +32,4 @@ const reFormat = (html, config) => {
   }
 
   return html
-    .replace(/,\s*/g, ', ')
-    .replace(/(\s+style="\s+)([\s\S]*?)(\s+")/g, (match, p1, p2, p3) => {
-      return p1.replace(/\n\s+?(style)/g, ' $1').trimEnd()
-        + p2.replace(/\s+/g, ' ').trim()
-        + p3.trim()
-    })
 }


### PR DESCRIPTION
Fixes #1152 

This PR removes the custom regexes that keep causing issues in the `reFormat()` function of the prettifier.

Using `embeddedLanguageFormatting: 'off'` is enough to fix things like `&quot;` in font stacks, or inline CSS font stacks being output on separate lines.
