### PR TITLE
fix: serve build templates array with nested directory structure

### DIFF
--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -107,7 +107,7 @@ const serve = async (env = 'local', config = {}) => {
           let ext = ''
 
           if (Array.isArray(config.build.templates)) {
-            const match = config.build.templates.find(template => template.source === path.parse(file).dir)
+            const match = config.build.templates.find(template => path.parse(file).dir.includes(path.normalize(template.source)))
             source = path.normalize(get(match, 'source'))
             dest = path.normalize(get(match, 'destination.path', 'build_local'))
             ext = get(match, 'destination.ext', 'html')


### PR DESCRIPTION
I would like to fix an issue related to serving build templates with a nested directory structure.

## Issue Description
The current implementation fails when dealing with templates organized in nested directories and configured with `templates` as `Array`, during the `serve` command rebuild process of nested template files.

## Proposed fix
I propose to make the matching of a file to a template source using `String.prototype.includes()` function instead of strict equality (`===`).


## Example: 
```
// Simplified monorepo directory structure with shared packages for different projects
├───projects
│   ├───project-1
│   │   └───maizzle // <-- config.js
│   │       └───templates
│   │           ├───p1-1
│   │           └───p1-2
│   └───project-2
└───shared-packages
    ├───package-A
    │   └───templates  // ✅ 'serve' rebuild of files from 'shared-packages/package-A/templates/*.html' is OK
    │       └───a // ❌ 'serve' rebuild of nested files from 'shared-packages/package-A/templates/a/**/*.html' is failed
    │           ├───a1 // ❌
    │           └───a2 // ❌
    └───package-B
        └───templates
```
``` 
// Shortened expected output result
├───p1-1
├───p1-2
└───package-A
    └───a
        ├───a1
        └───a2
```
```js
// config.js file
module.exports = {
  build: {
    templates: [
      {
        source: 'src/templates',
        destination: {
          path: destinationPath,
        },
      },
      {
        source: '../../../shared-packages/package-A/templates',
        destination: {
          path: `${destinationPath}/package-A`,
        },
      },
     // ...
    ],
  }   
}
```

Thank you for the great work!