### PR TITLE
refactor: render original reference when a variable is undefined

### DIFF
--- a/src/generators/posthtml/index.js
+++ b/src/generators/posthtml/index.js
@@ -16,6 +16,7 @@ module.exports = async (html, config) => {
   const expressionsOptions = merge(
     {
       loopTags: ['each', 'for'],
+      missingLocal: '{local}',
       strictMode: false
     },
     get(config, 'build.posthtml.expressions', {}),

--- a/test/test-tostring.js
+++ b/test/test-tostring.js
@@ -85,11 +85,11 @@ test('locals work when defined in all supported places', async t => {
     }
   })
 
-  t.is(result, `1, 2, 3, undefined`)
+  t.is(result, `1, 2, 3, {{ inline }}`)
 })
 
 test.serial('prevents overwriting page object', async t => {
-  const result = await renderString(`{{ page.one }}, {{ two }}, {{ three }}, {{ inline }}`, {
+  const result = await renderString(`{{ page.one }}, {{ page.two }}, {{ page.three }}, {{ inline }}`, {
     maizzle: {
       one: 1,
       build: {
@@ -111,7 +111,7 @@ test.serial('prevents overwriting page object', async t => {
     }
   })
 
-  t.is(result, `1, undefined, undefined, undefined`)
+  t.is(result, `1, 2, 3, {{ inline }}`)
 })
 
 test('preserves css in marked style tags (tailwindcss)', async t => {

--- a/types/expressions.d.ts
+++ b/types/expressions.d.ts
@@ -75,4 +75,26 @@ export default interface ExpressionsConfig {
   @default false
   */
   strictMode?: boolean;
+
+  /**
+  What to render when referencing a value that is not defined in `locals`.
+
+  By default the original expression reference will be output, i.e. `{{ foo }}`.
+
+  @default '{local}'
+
+  @example
+
+  ```
+  // Output empty string if value is not defined
+  missingLocal: ''
+
+  // Output original reference if value is not defined
+  missingLocal: '{local}'
+
+  // Output custom string if value is not defined
+  missingLocal: 'ERR_NO_VALUE: {local}'
+  ```
+  */
+  missingLocal?: string;
 }


### PR DESCRIPTION
This PR changes the default handling of `undefined` expressions so that the original reference is rendered in the compiled HTML, instead of the string `undefined`.

This is particularly useful when dealing with ESP placeholders/merge tags, meaning that you can now just do this:

```html
<a href="{{ unsubscribe_url }}">Unsubscribe</a> from these emails.
```

... and have it output exactly like that - no need to ignore the expression with `@{{ unsubscribe_url }}`.
