### PR TITLE
fix: expressions config merging order

### DIFF
--- a/src/generators/posthtml/index.js
+++ b/src/generators/posthtml/index.js
@@ -20,7 +20,7 @@ module.exports = async (html, config) => {
       strictMode: false
     },
     get(componentsUserOptions, 'expressions', {}),
-    get(config, 'build.posthtml.expressions', {}),
+    get(config, 'build.posthtml.expressions', {})
   )
 
   const locals = merge(

--- a/src/generators/posthtml/index.js
+++ b/src/generators/posthtml/index.js
@@ -19,8 +19,8 @@ module.exports = async (html, config) => {
       missingLocal: '{local}',
       strictMode: false
     },
+    get(componentsUserOptions, 'expressions', {}),
     get(config, 'build.posthtml.expressions', {}),
-    get(componentsUserOptions, 'expressions', {})
   )
 
   const locals = merge(


### PR DESCRIPTION
Fixes the order in which expressions options are merged, so that options defined in `build.posthtml.expressions` will work.
