### PR TITLE
fix: throw if a template cannot be rendered

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -7,26 +7,21 @@ const build = async (env = 'local', config = {}) => {
   const start = new Date()
   const spinner = ora('Building emails...').start()
 
-  try {
-    const {files, parsed} = await Output.toDisk(env, spinner, config)
+  const {files, parsed} = await Output.toDisk(env, spinner, config)
 
-    const elapsedSeconds = (Date.now() - start) / 1000
+  const elapsedSeconds = (Date.now() - start) / 1000
 
-    if (get(config, 'build.command') === 'serve') {
-      if (get(config, 'build.console.clear')) {
-        clearConsole()
-      }
-
-      spinner.succeed(`Re-built ${parsed.length} templates in ${elapsedSeconds}s`)
-    } else {
-      spinner.succeed(`Built ${parsed.length} templates in ${elapsedSeconds}s`)
+  if (get(config, 'build.command') === 'serve') {
+    if (get(config, 'build.console.clear')) {
+      clearConsole()
     }
 
-    return {files}
-  } catch (error) {
-    spinner.fail(error.message)
-    throw error
+    spinner.succeed(`Re-built ${parsed.length} templates in ${elapsedSeconds}s`)
+  } else {
+    spinner.succeed(`Built ${parsed.length} templates in ${elapsedSeconds}s`)
   }
+
+  return {files}
 }
 
 module.exports = build

--- a/src/generators/output/to-disk.js
+++ b/src/generators/output/to-disk.js
@@ -236,7 +236,9 @@ module.exports = async (env, spinner, config) => {
               files = [...new Set([...files, ...contents])]
             })
         })
-        .catch(error => spinner.warn(error.message))
+        .catch(error => {
+          throw error
+        })
     }
   }
 

--- a/test/test-todisk.js
+++ b/test/test-todisk.js
@@ -20,6 +20,21 @@ test('throws if config cannot be computed', async t => {
   }, {instanceOf: Error})
 })
 
+test('throws if a template cannot be rendered', async t => {
+  await t.throwsAsync(async () => {
+    await Maizzle.build('maizzle-ci', {
+      build: {
+        templates: {
+          source: 'test/stubs/breaking',
+          destination: {
+            path: t.context.folder
+          }
+        }
+      }
+    })
+  }, {instanceOf: Error})
+})
+
 test('skips if no templates found', async t => {
   const {files} = await Maizzle.build('maizzle-ci', {
     build: {
@@ -427,21 +442,6 @@ test('supports multiple assets array paths with templates array', async t => {
 
   t.true(files.includes(`${t.context.folder}/assets/extras4/foo1.bar`))
   t.true(files.includes(`${t.context.folder}/assets/extras4/foo2.bar`))
-})
-
-test('warns if a template cannot be rendered and `fail` option is undefined', async t => {
-  const {files} = await Maizzle.build('maizzle-ci', {
-    build: {
-      templates: {
-        source: 'test/stubs/breaking',
-        destination: {
-          path: t.context.folder
-        }
-      }
-    }
-  })
-
-  t.false(files.includes('empty.html'))
 })
 
 test('warns if a template cannot be rendered and `fail` option is `verbose`', async t => {


### PR DESCRIPTION
This PR fixes #1255, an issue where the process was not correctly exiting because of an error that was being caught, but not thrown.