### PR TITLE
Allow capturing groups replacement in replaceStrings.js

### DIFF
--- a/src/transformers/replaceStrings.js
+++ b/src/transformers/replaceStrings.js
@@ -6,6 +6,7 @@ import { parser as parse } from 'posthtml-parser'
 import posthtmlConfig from '../posthtml/defaultConfig.js'
 import defaultPostHTMLConfig from '../posthtml/defaultConfig.js'
 
+const captureRegex = new RegExp('\\$\\d', 'gi')
 const posthtmlPlugin = (replacements = {}) => tree => {
   if (!isEmpty(replacements)) {
     const regexes = Object.entries(replacements).map(([k, v]) => [new RegExp(k, 'gi'), v])
@@ -15,7 +16,8 @@ const posthtmlPlugin = (replacements = {}) => tree => {
       render(tree).replace(patterns, matched => {
         for (const [regex, replacement] of regexes) {
           if (regex.test(matched)) {
-            return replacement
+            if (captureRegex.test(replacement)) return matched.replace(regex, replacement)
+            else return replacement
           }
         }
       }),
@@ -35,3 +37,4 @@ export async function replaceStrings(html = '', replacements = {}, posthtmlOptio
     .process(html, merge(posthtmlOptions, posthtmlConfig))
     .then(result => result.html)
 }
+

--- a/src/transformers/replaceStrings.js
+++ b/src/transformers/replaceStrings.js
@@ -18,7 +18,7 @@ const posthtmlPlugin = (replacements = {}) => tree => {
         for (const [regex, replacement] of regexes) {
           if (regex.test(matched)) {
             if (captureRegex.test(replacement)) {
-              matched.replace(regex, replacement)
+              return matched.replace(regex, replacement)
             }
 
             return replacement

--- a/src/transformers/replaceStrings.js
+++ b/src/transformers/replaceStrings.js
@@ -6,7 +6,8 @@ import { parser as parse } from 'posthtml-parser'
 import posthtmlConfig from '../posthtml/defaultConfig.js'
 import defaultPostHTMLConfig from '../posthtml/defaultConfig.js'
 
-const captureRegex = new RegExp('\\$\\d', 'gi')
+const captureRegex = /\$\d/gi
+
 const posthtmlPlugin = (replacements = {}) => tree => {
   if (!isEmpty(replacements)) {
     const regexes = Object.entries(replacements).map(([k, v]) => [new RegExp(k, 'gi'), v])
@@ -16,8 +17,11 @@ const posthtmlPlugin = (replacements = {}) => tree => {
       render(tree).replace(patterns, matched => {
         for (const [regex, replacement] of regexes) {
           if (regex.test(matched)) {
-            if (captureRegex.test(replacement)) return matched.replace(regex, replacement)
-            else return replacement
+            if (captureRegex.test(replacement)) {
+              matched.replace(regex, replacement)
+            }
+
+            return replacement
           }
         }
       }),
@@ -37,4 +41,3 @@ export async function replaceStrings(html = '', replacements = {}, posthtmlOptio
     .process(html, merge(posthtmlOptions, posthtmlConfig))
     .then(result => result.html)
 }
-

--- a/test/transformers.test.js
+++ b/test/transformers.test.js
@@ -581,7 +581,8 @@ describe.concurrent('Transformers', () => {
     expect(await replaceStrings('initial text', {})).toBe('initial text')
     expect(await replaceStrings('initial text', { '/not/': 'found' })).toBe('initial text')
     expect(await replaceStrings('initial text', { 'initial': 'updated' })).toBe('updated text')
-
+    expect(await replaceStrings('initial [text]', { '(initial) \\[(text)\\]': '($2) updated' })).toBe('(text) updated')
+    
     expect(
       await useTransformers('initial text', { replaceStrings: { 'initial': 'updated' } }).then(({ html }) => html)
     ).toBe('updated text')


### PR DESCRIPTION
Hi

This adjustement aims to let the replacement string make use of the capturing group in the regex.

In the version 4, replace strings transformers allows us to replace (1) by <sup>(1)</sup>.
Which is not the case in the version 5, i see it as a regression because i personnally used it in that way but maybe it was intended.

In my PR choosed to detect if the replacement string contains a capturing group reference in order to not have the overload of regex replacement if it's not wanted.

Thank for your time and this project !