### PR TITLE
PostHTML Expression config not used in render

### DIFF
--- a/src/transformers/replaceStrings.js
+++ b/src/transformers/replaceStrings.js
@@ -6,8 +6,6 @@ import { parser as parse } from 'posthtml-parser'
 import posthtmlConfig from '../posthtml/defaultConfig.js'
 import defaultPostHTMLConfig from '../posthtml/defaultConfig.js'
 
-const captureRegex = /\$\d/gi
-
 const posthtmlPlugin = (replacements = {}) => tree => {
   if (!isEmpty(replacements)) {
     const regexes = Object.entries(replacements).map(([k, v]) => [new RegExp(k, 'gi'), v])

--- a/src/transformers/replaceStrings.js
+++ b/src/transformers/replaceStrings.js
@@ -18,7 +18,7 @@ const posthtmlPlugin = (replacements = {}) => tree => {
         for (const [regex, replacement] of regexes) {
           if (regex.test(matched)) return matched.replace(regex, replacement)
         }
-      return matched
+        return matched
       }),
       defaultPostHTMLConfig
     )

--- a/src/transformers/replaceStrings.js
+++ b/src/transformers/replaceStrings.js
@@ -16,14 +16,9 @@ const posthtmlPlugin = (replacements = {}) => tree => {
     return parse(
       render(tree).replace(patterns, matched => {
         for (const [regex, replacement] of regexes) {
-          if (regex.test(matched)) {
-            if (captureRegex.test(replacement)) {
-              return matched.replace(regex, replacement)
-            }
-
-            return replacement
-          }
+          if (regex.test(matched)) return matched.replace(regex, replacement)
         }
+      return matched
       }),
       defaultPostHTMLConfig
     )

--- a/test/transformers.test.js
+++ b/test/transformers.test.js
@@ -582,6 +582,7 @@ describe.concurrent('Transformers', () => {
     expect(await replaceStrings('initial text', { '/not/': 'found' })).toBe('initial text')
     expect(await replaceStrings('initial text', { 'initial': 'updated' })).toBe('updated text')
     expect(await replaceStrings('initial [text]', { '(initial) \\[(text)\\]': '($2) updated' })).toBe('(text) updated')
+    expect(await replaceStrings('«initial» «text»', { '«(.*?)»' : '«&nbsp;$1&nbsp;»' })).toBe('«&nbsp;initial&nbsp;» «&nbsp;text&nbsp;»')
     
     expect(
       await useTransformers('initial text', { replaceStrings: { 'initial': 'updated' } }).then(({ html }) => html)


### PR DESCRIPTION
Hi!

The expression configuration in build.expression, is not merged correctly just before rendering.

In my use case i want te remove locals scripts, and on the V5 nothing is removed.
After some investigation i saw that the merge with the locals key in expression config was not done properly.

I added some test that you can check. Maybe you'll want this test not to be in the component loading test. Tell me if you want me to add a new test.

Thanks for your time once more.