### PR TITLE
revert: exposing posthtml compiler in events

### DIFF
--- a/src/generators/render.js
+++ b/src/generators/render.js
@@ -60,8 +60,6 @@ export async function render(html = '', config = {}) {
    * @param {string} options.html - The HTML to be transformed
    * @param {Object} options.matter - The front matter data
    * @param {Object} options.config - The current template config
-   * @param {function} options.posthtml - The PostHTML compiler
-   * @param {Object} options.transform - The transformers object
    * @returns {string} - The transformed HTML, or the original one if nothing was returned
    */
   if (typeof templateConfig.beforeRender === 'function') {
@@ -69,7 +67,6 @@ export async function render(html = '', config = {}) {
       html: content,
       matter: matterData,
       config: templateConfig,
-      posthtml: compilePostHTML,
     })) ?? content
   }
 
@@ -83,8 +80,6 @@ export async function render(html = '', config = {}) {
    * @param {string} options.html - The HTML to be transformed
    * @param {Object} options.matter - The front matter data
    * @param {Object} options.config - The current template config
-   * @param {function} options.posthtml - The PostHTML compiler
-   * @param {Object} options.transform - The transformers object
    * @returns {string} - The transformed HTML, or the original one if nothing was returned
    */
   if (typeof templateConfig.afterRender === 'function') {
@@ -92,7 +87,6 @@ export async function render(html = '', config = {}) {
       html: compiled.html,
       matter: matterData,
       config: templateConfig,
-      posthtml: compilePostHTML,
     })) ?? compiled.html
   }
 
@@ -118,8 +112,6 @@ export async function render(html = '', config = {}) {
    * @param {string} options.html - The HTML to be transformed
    * @param {Object} options.matter - The front matter data
    * @param {Object} options.config - The current template config
-   * @param {function} options.posthtml - The PostHTML compiler
-   * @param {Object} options.transform - The transformers object
    * @returns {string} - The transformed HTML, or the original one if nothing was returned
    */
   if (typeof templateConfig.afterTransformers === 'function') {
@@ -127,7 +119,6 @@ export async function render(html = '', config = {}) {
       html: compiled.html,
       matter: matterData,
       config: templateConfig,
-      posthtml: compilePostHTML,
     })) ?? compiled.html
   }
 

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -28,11 +28,11 @@ describe.concurrent('Render', () => {
 
   test('Runs the `beforeRender` event', async () => {
     const { html } = await render('<div class="inline">{{ page.foo }}</div>', {
-      beforeRender({ config, posthtml }) {
+      beforeRender({ config, matter }) {
         config.foo = 'bar'
 
         expect(config).toBeInstanceOf(Object)
-        expect(posthtml).toBeInstanceOf(Function)
+        expect(matter).toBeInstanceOf(Object)
       }
     })
 
@@ -41,13 +41,13 @@ describe.concurrent('Render', () => {
 
   test('Runs the `afterRender` event', async () => {
     const { html } = await render('<div class="inline">foo</div>', {
-      afterRender({ config, posthtml }) {
+      afterRender({ config, matter }) {
         config.replaceStrings = {
           foo: 'bar'
         }
 
         expect(config).toBeInstanceOf(Object)
-        expect(posthtml).toBeInstanceOf(Function)
+        expect(matter).toBeInstanceOf(Object)
       }
     })
 
@@ -59,9 +59,9 @@ describe.concurrent('Render', () => {
       replaceStrings: {
         foo: 'bar'
       },
-      afterTransformers({ html, config, posthtml }) {
+      afterTransformers({ html, matter, config }) {
         expect(config).toBeInstanceOf(Object)
-        expect(posthtml).toBeInstanceOf(Function)
+        expect(matter).toBeInstanceOf(Object)
 
         return html.replace('bar', 'baz')
       }

--- a/types/events.d.ts
+++ b/types/events.d.ts
@@ -1,7 +1,5 @@
 import type Config from "./config";
 
-type PostHTMLType = (html: string, config: Config) => { html: string; config: Config };
-
 export default interface Events {
   /**
   * Runs after the Environment config has been computed, but before Templates are processed.
@@ -57,13 +55,6 @@ export default interface Events {
      * This is the Environment config merged with the Template's Front Matter.
      */
     config: Config;
-    /**
-     * A function to process an HTML string with PostHTML.
-     *
-     * @param {string} html The HTML string to process.
-     * @param {Config} config The Maizzle config object.
-     */
-    posthtml: PostHTMLType;
   }) => string | Promise<string>;
 
   /**
@@ -98,13 +89,6 @@ export default interface Events {
      * This is the Environment config merged with the Template's Front Matter.
      */
     config: Config;
-    /**
-    * A function to process an HTML string with PostHTML.
-    *
-    * @param {string} html The HTML string to process.
-    * @param {Config} config The Maizzle config object.
-    */
-    posthtml: PostHTMLType;
   }) => string | Promise<string>;
 
   /**
@@ -139,13 +123,6 @@ export default interface Events {
      * This is the Environment config merged with the Template's Front Matter.
      */
     config: Config;
-    /**
-    * A function to process an HTML string with PostHTML.
-    *
-    * @param {string} html The HTML string to process.
-    * @param {Config} config The Maizzle config object.
-    */
-    posthtml: PostHTMLType;
   }) => string | Promise<string>;
 
   /**


### PR DESCRIPTION
can just import and use `render()` instead

<!--

Thank you for your interest in contributing to Maizzle!

**Please ask first before starting work on any significant new features.**

https://github.com/maizzle/framework/blob/master/.github/CONTRIBUTING.md

-->
