### PR TITLE
Fix PostHTML expression config

### DIFF
--- a/src/posthtml/index.js
+++ b/src/posthtml/index.js
@@ -77,9 +77,10 @@ export async function process(html = '', config = {}) {
     components(
       merge(
         {
-          expressions: {
-            locals,
-          }
+          expressions: merge(
+            expressionsOptions,
+            {locals}
+          )
         },
         componentsUserOptions,
         defaultComponentsConfig

--- a/src/posthtml/index.js
+++ b/src/posthtml/index.js
@@ -78,8 +78,8 @@ export async function process(html = '', config = {}) {
       merge(
         {
           expressions: merge(
+            { locals },
             expressionsOptions,
-            {locals}
           )
         },
         componentsUserOptions,

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -123,7 +123,12 @@ describe.concurrent('Render', () => {
       </x-list>
     `
 
-    const { html } = await render(source, {
+    const { html } = await render(source, { 
+      build: {
+        expressions: {
+          removeScriptLocals: true
+        }
+      },
       components: {
         folders: ['test/stubs/components'],
       }

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -113,7 +113,7 @@ describe.concurrent('Render', () => {
   })
 
   test('fetch component', async () => {
-    const source = `
+    const { html } = await render(`
       <x-list>
         <fetch url="test/stubs/data.json">
           {{ undefinedVariable }}
@@ -121,19 +121,31 @@ describe.concurrent('Render', () => {
           @{{ ignored }}
         </fetch>
       </x-list>
-    `
-
-    const { html } = await render(source, { 
-      build: {
-        expressions: {
-          removeScriptLocals: true
-        }
-      },
+    `, {
       components: {
         folders: ['test/stubs/components'],
       }
     })
 
     expect(cleanString(html)).toBe('<h1>Results</h1> {{ undefinedVariable }} Leanne Graham, Ervin Howell {{ ignored }}')
+  })
+
+  test('uses expressions options', async () => {
+    const { html } = await render(`
+      <script locals>
+        module.exports = { name: 'John' }
+      </script>
+      <h1>Hello {{ name }}</h1>
+    `,
+      {
+        build: {
+          expressions: {
+            removeScriptLocals: true,
+          }
+        }
+      }
+    )
+
+    expect(cleanString(html)).toBe('<h1>Hello John</h1>')
   })
 })

--- a/test/stubs/components/list.html
+++ b/test/stubs/components/list.html
@@ -1,3 +1,4 @@
+<script locals></script>
 <h1>Results</h1>
 
 <yield />

--- a/test/stubs/components/list.html
+++ b/test/stubs/components/list.html
@@ -1,4 +1,3 @@
-<script locals></script>
 <h1>Results</h1>
 
 <yield />


### PR DESCRIPTION
Hi!

The expression configuration in build.expression, is not merged correctly just before rendering.

In my use case i want te remove locals scripts, and on the V5 nothing is removed.
After some investigation i saw that the merge with the locals key in expression config was not done properly.

I added some test that you can check. Maybe you'll want this test not to be in the component loading test. Tell me if you want me to add a new test.

Thanks for your time once more.