### PR TITLE
Update watcher

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -214,7 +214,19 @@ export default async (config = {}) => {
    */
   let isWatcherReady = false
   chokidar
-    .watch([...templatePaths, ...get(config, 'components.folders', defaultComponentsConfig.folders)])
+    .watch(
+      [
+        ...templatePaths,
+        ...get(config, 'components.folders', defaultComponentsConfig.folders)
+      ],
+      {
+        ignoreInitial: true,
+        awaitWriteFinish: {
+          stabilityThreshold: 150,
+          pollInterval: 25,
+        },
+      }
+    )
     .on('change', async () => {
       if (viewing) {
         await renderUpdatedFile(viewing, config)
@@ -326,6 +338,10 @@ export default async (config = {}) => {
         get(config, 'build.output.path', 'build_production'),
       ],
       ignoreInitial: true,
+      awaitWriteFinish: {
+        stabilityThreshold: 150,
+        pollInterval: 25,
+      },
     })
     .on('change', async file => await globalPathsHandler(file, 'change'))
     .on('add', async file => await globalPathsHandler(file, 'add'))

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -247,8 +247,8 @@ export default async (config = {}) => {
    * Watch for changes in the config file, Tailwind CSS config, and CSS files
    */
   const globalWatchedPaths = new Set([
-    'config*.{js,cjs}',
-    'maizzle.config*.{js,cjs}',
+    'config*.{js,cjs,ts}',
+    'maizzle.config*.{js,cjs,ts}',
     'tailwind*.config.{js,ts}',
     '**/*.css',
     ...get(config, 'server.watch', [])

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -247,9 +247,9 @@ export default async (config = {}) => {
    * Watch for changes in the config file, Tailwind CSS config, and CSS files
    */
   const globalWatchedPaths = new Set([
-    'config*.js',
-    'maizzle.config*.js',
-    'tailwind*.config.js',
+    'config*.{js,cjs}',
+    'maizzle.config*.{js,cjs}',
+    'tailwind*.config.{js,ts}',
     '**/*.css',
     ...get(config, 'server.watch', [])
   ])

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -5,9 +5,9 @@ import { describe, expect, test, beforeAll } from 'vitest'
 const init = async () => {
   await serve({
     build: {
-      content: 'test/fixtures/build/**/*.html',
+      content: ['test/fixtures/build/**/*.html'],
       static: {
-        source: 'test/fixtures/build/**/*.png',
+        source: ['test/fixtures/build/**/*.png'],
       }
     },
     components: {


### PR DESCRIPTION
- [x] watch more config file extensions, like `.cjs` and `.ts`
- [x] fix race condition resulting in `received empty string` error in local dev
- [x] serve assets added to watch paths after dev server was started

Fixes #1324
Fixes #1323 
Fixes #1321 