### PR TITLE
`build.current` types

### DIFF
--- a/types/build.d.ts
+++ b/types/build.d.ts
@@ -116,4 +116,31 @@ export default interface BuildConfig {
    * ```
    */
   summary?: boolean;
+
+  /**
+   * Information about the Template currently being compiled.
+   *
+   * @example
+   *
+   * ```
+   * {
+      path: {
+        root: 'build_production',
+        dir: 'build_production',
+        base: 'transactional.html',
+        ext: '.html',
+        name: 'transactional'
+      }
+    }
+    * ```
+   */
+  current?: {
+    path?: {
+      root: string;
+      dir: string;
+      base: string;
+      ext: string;
+      name: string;
+    };
+  };
 }


### PR DESCRIPTION
Adds type definitions for `build.current` so that we get autocomplete when accessing it in events.

Closes #1322 
