### PR TITLE
fix: error when filename has a space

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -168,7 +168,7 @@ export default async (config = {}) => {
       }
 
       try {
-        const filePath = templatePaths.find(t => t.endsWith(req.url.slice(1)))
+        const filePath = templatePaths.find(t => t.endsWith(decodeURI(req.url.slice(1))))
 
         // Set the file being viewed
         viewing = filePath

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -27,7 +27,7 @@ function groupFilesByDirectories(globs, files) {
         const fileName = parts[parts.length - 1]
         current[fileName] = {
           name: fileName,
-          href: file,
+          href: encodeURI(file),
         }
       }
     })


### PR DESCRIPTION
This PR solves issue when the filename contains space, or any other URL encoded symbol. 

![image](https://github.com/user-attachments/assets/002ebd0f-8e22-4e28-97be-25a3bc8cedc3)
