### PR TITLE
fix: output files at root of output.path

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -107,7 +107,7 @@ export default async (config = {}) => {
     /**
      * Check that templates to be built, actually exist
      */
-    const contentPaths = get(config, 'build.content', ['src/templates/**/*.html'])
+    const contentPaths = get(config, 'build.content', ['emails/**/*.html'])
 
     const templateFolders = Array.isArray(contentPaths) ? contentPaths : [contentPaths]
     const templatePaths = await fg.glob([...new Set(templateFolders)])
@@ -122,7 +122,7 @@ export default async (config = {}) => {
      *
      * Copies each `build.content` path to the `build.output.path` directory.
      */
-    let from = get(config, 'build.output.from', ['src/templates', 'src'])
+    let from = get(config, 'build.output.from', ['emails'])
 
     const globPathsToCopy = contentPaths.map(glob => {
       // Keep negated paths as they are

--- a/src/generators/plaintext.js
+++ b/src/generators/plaintext.js
@@ -150,7 +150,7 @@ export async function writePlaintextFile(plaintext = '', config = {}) {
    * `config.build.output.path`
    */
   const plaintextConfig = get(config, 'plaintext')
-  let plaintextOutputPath = get(plaintextConfig, 'output.path', get(config, 'build.output.path'))
+  let plaintextOutputPath = get(plaintextConfig, 'output.path', '')
   const plaintextExtension = get(plaintextConfig, 'output.extension', 'txt')
 
   /**
@@ -158,7 +158,7 @@ export async function writePlaintextFile(plaintext = '', config = {}) {
    * output plaintext file in the same location as the HTML file.
    */
   if (plaintextConfig === true) {
-    plaintextOutputPath = get(config, 'build.output.path')
+    plaintextOutputPath = ''
   }
 
   /**

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -197,7 +197,7 @@ describe.concurrent('Build', () => {
       }
     )
 
-    expect(files).toContain(`${ctx.folder}/test/fixtures/build/${ctx.folder}/beforeCreate.txt`)
+    expect(files).toContain(`${ctx.folder}/test/fixtures/build/beforeCreate.txt`)
   })
 
   test('Expands <link> tags', async ctx => {


### PR DESCRIPTION
This PR fixes an issue with how compiled files are output, essentially reverting to the old behavior in 4.x where HTML files were output relative to the root of the destination directory, instead of copying over the folder that contains them.

The docs also now explain how the underlying mechanism works and how it can be customized when using multiple content sources:

https://maizzle.com/docs/configuration/build#from-caveat

Fixes #1417