### PR TITLE
Correctly handle base64 CSS values when using `preferUnitlessValues`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -346,6 +346,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -174,27 +174,6 @@ export function getFileExtensionsFromPattern(pattern) {
   return ['html'] // No recognizable extension pattern, default to 'html'
 }
 
-export function parseCSSRule(rule) {
-  // Step 1: Trim the input string
-  rule = rule.trim()
-
-  // Step 2: Find the index of the first colon
-  const colonIndex = rule.indexOf(':')
-
-  // Step 3: Extract property and value parts
-  if (colonIndex === -1) {
-    return {
-      property: '',
-      value: ''
-    }
-  }
-
-  const property = rule.slice(0, colonIndex).trim()
-  const value = rule.slice(colonIndex + 1).trim()
-
-  return { property, value }
-}
-
 /**
  * Normalize a string by removing extra whitespace.
  *

--- a/test/transformers/inlineCSS.test.js
+++ b/test/transformers/inlineCSS.test.js
@@ -181,4 +181,20 @@ describe.concurrent('Inline CSS', () => {
         </tr>
       </table>`))
   })
+
+  test('Works with `preferUnitlessValues` option disabled', async () => {
+    expect(
+      cleanString(
+        await inlineCSS(`
+          <style>.m-0 {margin: 0px}</style>
+          <p class="m-0">test</p>`,
+          {
+            preferUnitlessValues: false, // default is true
+          }
+        )
+      )
+    ).toBe(cleanString(`
+      <style></style>
+      <p style="margin: 0px">test</p>`))
+  })
 })

--- a/test/transformers/inlineCSS.test.js
+++ b/test/transformers/inlineCSS.test.js
@@ -122,6 +122,22 @@ describe.concurrent('Inline CSS', () => {
     ).toBe('<p class="bar" style="display: flex; color: red;"></p>')
   })
 
+  test('Works with `preferUnitlessValues` option disabled', async () => {
+    const result = cleanString(
+      await inlineCSS(`
+        <style>.m-0 {margin: 0px}</style>
+        <p class="m-0">test</p>`,
+        {
+          preferUnitlessValues: false, // default is true
+        }
+      )
+    )
+
+    expect(result).toBe(cleanString(`
+      <style></style>
+      <p style="margin: 0px">test</p>`))
+  })
+
   test('Works with `excludedProperties` option', async () => {
     expect(
       cleanString(
@@ -182,19 +198,20 @@ describe.concurrent('Inline CSS', () => {
       </table>`))
   })
 
-  test('Works with `preferUnitlessValues` option disabled', async () => {
+  test('Works with base64-encoded CSS values', async () => {
     expect(
       cleanString(
         await inlineCSS(`
-          <style>.m-0 {margin: 0px}</style>
-          <p class="m-0">test</p>`,
-          {
-            preferUnitlessValues: false, // default is true
-          }
+          <style>
+            .base64 {
+              background-image: url("data:image/gif;base64,R0lGODdhAQABAPAAAP8AAAAAACwAAAAAAQABAAACAkQBADs=");
+            }
+          </style>
+          <p class="base64">test</p>`,
         )
       )
     ).toBe(cleanString(`
-      <style></style>
-      <p style="margin: 0px">test</p>`))
+      <style> </style>
+      <p style="background-image: url('data:image/gif;base64,R0lGODdhAQABAPAAAP8AAAAAACwAAAAAAQABAAACAkQBADs=')">test</p>`))
   })
 })


### PR DESCRIPTION
This PR fixes #1466, an issue where base64-encoded CSS values were incorrectly split at their `;` when using `css.inline.preferUnitlessValues` (which is `true` by default), resulting in invalid inline CSS values.