### PR TITLE
fix: broad regex when checking for selectors to preserve

### DIFF
--- a/src/transformers/inline.js
+++ b/src/transformers/inline.js
@@ -146,7 +146,7 @@ export async function inline(html = '', options = {}) {
       const { selector } = rule
 
       // Add the selector to the set as long as it's not a pseudo selector
-      if (!/(^|[^\\])::?[\w-]+/.test(selector)) {
+      if (!/.+[^\\\s]::?\w+/.test(selector)) {
         selectors.add({
           name: selector,
           prop: get(rule.nodes[0], 'prop')


### PR DESCRIPTION
This fixes an issue with preserving selectors after inlining, where a regex was too broad and could have caused selectors like `space-y-6` to be preserved after inlining.

Something like this:

```html
<ul class="space-y-6">
  <li></li>
  <li></li>
  <li></li>
</ul>
```

Must output this with inlining enabled:

```html
<ul class="space-y-6">
  <li></li>
  <li style="margin: 24px 0 0"></li>
  <li style="margin: 24px 0 0"></li>
</ul>
```

... and not this:

```html
<style>
.space-y-6 > :not([hidden]) ~ :not([hidden]) {
  margin-top: 24px !important;
  margin-bottom: 0px !important;
}
</style>

<ul class="space-y-6">
  <li></li>
  <li style="margin: 24px 0 0"></li>
  <li style="margin: 24px 0 0"></li>
</ul>
```