### PR TITLE
fix: posthtml.plugins.before

### DIFF
--- a/src/posthtml/index.js
+++ b/src/posthtml/index.js
@@ -98,8 +98,10 @@ export async function process(html = '', config = {}) {
     [].concat(componentsConfig.fileExtension)
   ))
 
+  const beforePlugins = get(config, 'posthtml.plugins.before', [])
+
   return posthtml([
-    ...get(config, 'posthtml.plugins.before', []),
+    ...beforePlugins,
     envTags(config.env),
     envAttributes(config.env),
     expandLinkTag,
@@ -110,7 +112,13 @@ export async function process(html = '', config = {}) {
     postcssPlugin,
     envTags(config.env),
     envAttributes(config.env),
-    ...get(config, 'posthtml.plugins.after', get(config, 'posthtml.plugins', []))
+    ...get(
+      config,
+      'posthtml.plugins.after',
+      beforePlugins.length > 0
+        ? []
+        : get(config, 'posthtml.plugins', [])
+    ),
   ])
     .process(html, posthtmlOptions)
     .then(result => ({


### PR DESCRIPTION
This PR ensures that PostHTML plugins registered to run `before` all others will work and not throw an error.

Currently they will throw because the fallback for plugins registered to run `after` refers to an object (`poshtml.plugins` is an object instead of the expected array, when `posthtml.plugins.before` is defined).

Basically this fix allows you to use `posthtml.plugins.before` and `posthtml.plugins.after` or, for backwards-compatibility, you can just use `posthtml.plugins` to define custom PostHTML plugins (which will run last, just like `posthtml.plugins.after`).