### PR TITLE
fix: skip parsing invalid css in preferUnitlessValues

### DIFF
--- a/src/transformers/inline.js
+++ b/src/transformers/inline.js
@@ -189,30 +189,31 @@ export async function inline(html = '', options = {}) {
 
           // 1. `preferUnitlessValues`
           if (styleAttr) {
-            // Parse the inline styles using postcss
-            const root = postcss.parse(`* { ${styleAttr} }`)
+            try {
+              const root = postcss.parse(`* { ${styleAttr} }`)
 
-            root.first.each((decl) => {
-              const property = decl.prop
-              let value = decl.value
+              root.first.each((decl) => {
+                const property = decl.prop
+                let value = decl.value
 
-              if (value && options.preferUnitlessValues) {
-                value = value.replace(
-                  /\b0(px|rem|em|%|vh|vw|vmin|vmax|in|cm|mm|pt|pc|ex|ch)\b/g,
-                  '0'
-                )
-              }
+                if (value && options.preferUnitlessValues) {
+                  value = value.replace(
+                    /\b0(px|rem|em|%|vh|vw|vmin|vmax|in|cm|mm|pt|pc|ex|ch)\b/g,
+                    '0'
+                  )
+                }
 
-              if (property) {
-                inlineStyles[property] = value
-              }
-            })
+                if (property) {
+                  inlineStyles[property] = value
+                }
+              })
 
-            // Update the element's style attribute with the new value
-            $(el).attr(
-              'style',
-              Object.entries(inlineStyles).map(([property, value]) => `${property}: ${value}`).join('; ')
-            )
+              // Update the element's style attribute with the new value
+              $(el).attr(
+                'style',
+                Object.entries(inlineStyles).map(([property, value]) => `${property}: ${value}`).join('; ')
+              )
+            } catch {}
           }
 
           // Get the classes from the element's class attribute

--- a/test/transformers/inlineCSS.test.js
+++ b/test/transformers/inlineCSS.test.js
@@ -138,6 +138,19 @@ describe.concurrent('Inline CSS', () => {
       <p style="margin: 0px">test</p>`))
   })
 
+  test('`preferUnitlessValues` skips invalid inline CSS', async () => {
+    const result = cleanString(
+      await inlineCSS(`
+        <style>.m-0 {margin: 0px}</style>
+        <p class="m-0" style="color: #{{ $foo->theme }}">test</p>`
+      )
+    )
+
+    expect(result).toBe(cleanString(`
+      <style></style>
+      <p class="m-0" style="margin: 0px; color: #{{ $foo->theme }};">test</p>`))
+  })
+
   test('Works with `excludedProperties` option', async () => {
     expect(
       cleanString(


### PR DESCRIPTION
This PR fixes an issue where builds failed because [`preferUnitlessValues`](https://maizzle.com/docs/transformers/inline-css#preferunitlessvalues) (which is on by default) was throwing an error when encountering invalid inline CSS.

There are situations where inline CSS values contain expressions that are meant to be parsed later on, and the user just needs to have them output as they are, for example:

```html
<div style="color: #{{ $themeHexValue }}">
```

Normally PostCSS, which we use to parse the inline styles so we can remove units like `px` from 0-based CSS values like `margin: 0px`, will trip on that. This PR ensures it just silently skips it so that it's just output as-is.

Fixes #1510.