### PR TITLE
Specify `correct posthtml-base-url` minimum version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "postcss-safe-parser": "^7.0.0",
         "posthtml": "^0.16.6",
         "posthtml-attrs-parser": "^1.1.1",
-        "posthtml-base-url": "^3.1.4",
+        "posthtml-base-url": "^3.1.7",
         "posthtml-component": "^2.1.0",
         "posthtml-content": "^2.1.0",
         "posthtml-expressions": "^1.11.4",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "postcss-safe-parser": "^7.0.0",
     "posthtml": "^0.16.6",
     "posthtml-attrs-parser": "^1.1.1",
-    "posthtml-base-url": "^3.1.4",
+    "posthtml-base-url": "^3.1.7",
     "posthtml-component": "^2.1.0",
     "posthtml-content": "^2.1.0",
     "posthtml-expressions": "^1.11.4",


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Maizzle!

**Please ask first before starting work on any significant new features.**

https://github.com/maizzle/framework/blob/master/.github/CONTRIBUTING.md

-->

Maizzle 5.1 uses the `defaultTags` export from `posthtml-base-url` but this was only added in version 3.1.7 of that library. The `package.json` specifies that version ^3.1.4 is compatible, which is no longer accurate. This can cause issues if a Maizzle-based project specifies `posthtml-base-url@3.1.4–3.1.6` (throwing an error in the build process).