### PR TITLE
Whitespace error when rendering components

### DIFF
--- a/test/render.test.js
+++ b/test/render.test.js
@@ -146,4 +146,18 @@ describe.concurrent('Render', () => {
 
     expect(cleanString(html)).toBe('<h1>Hello John</h1>')
   })
+
+  test("whitespace", async () => {
+    const { html } = await render(`
+      <h1>Hello <x-span>John</x-span>, nice to meet you!</h1>
+    `,
+      {
+        components: {
+          folders: ["test/stubs/components"],
+        }
+      }
+    )
+
+    expect(cleanString(html)).toBe("<h1>Hello <span>John</span>, nice to meet you!</h1>");
+  })
 })

--- a/test/stubs/components/span.html
+++ b/test/stubs/components/span.html
@@ -1,0 +1,1 @@
+<span><yield /></span>


### PR DESCRIPTION
If you confirm this is a bug, I'll try to find a fix.

```
 FAIL  test/render.test.js > Render > whitespace
AssertionError: expected '<h1>Hello <span>John</span> , nice to…' to be '<h1>Hello <span>John</span>, nice to …' // Object.is equality

Expected: "<h1>Hello <span>John</span>, nice to meet you!</h1>"
Received: "<h1>Hello <span>John</span> , nice to meet you!</h1>"

 ❯ test/render.test.js:161:31
    159|     );
    160|
    161|     expect(cleanString(html)).toBe("<h1>Hello <span>John</span>, nice to meet you!</h1>");
       |                               ^
    162|   });
    163| })
```