### PR TITLE
Fix: Windows CRLF line ending compatibility for filters

### DIFF
--- a/src/transformers/filters/defaultFilters.js
+++ b/src/transformers/filters/defaultFilters.js
@@ -30,7 +30,7 @@ const modulo = (content, attribute) => Number.parseFloat(content) % Number.parse
 
 const multiply = (content, attribute) => Number.parseFloat(content) * Number.parseFloat(attribute)
 
-const newlineToBr = content => content.replace(/\n/g, '<br>')
+const newlineToBr = content => content.replace(/\r?\n/g, '<br>')
 
 const plus = (content, attribute) => Number.parseFloat(content) + Number.parseFloat(attribute)
 
@@ -76,7 +76,7 @@ const slice = (content, attribute) => {
   return content.slice(start, end)
 }
 
-const stripNewlines = content => content.replace(/\n/g, '')
+const stripNewlines = content => content.replace(/\r?\n/g, '')
 
 const trim = content => content.trim()
 


### PR DESCRIPTION
# Fix: Windows CRLF line ending compatibility for filters

## Root Cause
The regex /\n/g only matched Unix-style line breaks, leaving \r characters which corrupted the output.

## Solution
Updated regex to /\r?\n/g to support both LF and CRLF."

## Problem

The `filters.test.js` test was failing on Windows with this error:

```
expected '<!-- Append -->\r\n<div>testing appen…' to be '<!-- Append -->\r\n<div>testing appen…'
```

The diff showed corrupted output for `newline-to-br` and `strip-newlines` filters:

```diff
- <div><br>  test<br>  test<br></div>
+ <br></div>

- <div>  test  test</div>
+ </div>
```

## Root Cause

In `src/transformers/filters/defaultFilters.js`, two filter functions only matched Unix-style line endings (`\n`):

```js
// Line 33
const newlineToBr = content => content.replace(/\n/g, '<br>')

// Line 79
const stripNewlines = content => content.replace(/\n/g, '')
```

Windows uses `\r\n` (CRLF) for line breaks. The regex `/\n/g` only replaced the `\n` part, leaving the `\r` (carriage return) character in the output.

The `\r` character moves the cursor back to the beginning of the line, causing the output to appear truncated/overwritten when displayed or compared.

## Solution

Changed the regex from `/\n/g` to `/\r?\n/g` to handle both Windows (CRLF) and Unix (LF) line endings:

```js
// Line 33
const newlineToBr = content => content.replace(/\r?\n/g, '<br>')

// Line 79
const stripNewlines = content => content.replace(/\r?\n/g, '')
```