### PR TITLE
fix: downgrade juice to v10 to fix Bun module resolution error

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "html-crush": "^6.0.19",
     "is-url-superb": "^6.1.0",
     "istextorbinary": "^9.5.0",
-    "juice": "^11.1.0",
+    "juice": "^10.0.1",
     "lodash-es": "^4.17.21",
     "morphdom": "^2.7.4",
     "ora": "^8.1.0",


### PR DESCRIPTION
## Summary

Downgrade `juice` from `^11.1.0` to `^10.0.1` to fix a module resolution error that occurs when using Maizzle with Bun runtime.

## The Problem

When using Maizzle 5.4.0 with Bun, users encounter the following error:

```
Cannot find module 'entities/lib/decode.js'
Require stack:
- node_modules/htmlparser2/dist/commonjs/Tokenizer.js
```

This error was introduced in v5.4.0 when `juice` was upgraded from `^10.0.1` to `^11.1.0` (commit 52e1e8e).

## Root Cause Analysis

The issue stems from a dependency version conflict in the `entities` package:

**Dependency chain:**
```
maizzle/framework@5.4.0
└── juice@11.1.0
    ├── entities@^7.0.0         ← New in juice v11
    └── cheerio@1.0.0
        └── htmlparser2@9.1.0
            └── entities@^4.5.0  ← Expects lib/decode.js
```

**The `entities` package structure changed between versions:**

| Version | Import Path | Status |
|---------|-------------|--------|
| v4.x | `entities/lib/decode.js` | ✓ Works |
| v5+ | `entities/dist/decode.js` | Breaking change |
| v6+ | `entities/decode` | Breaking change |
| v7.x | `entities/decode` | Breaking change |

`htmlparser2@9.1.0` imports from `entities/lib/decode.js`, which no longer exists in `entities` v5+.

## Why cheerio and not posthtml-parser?

Maizzle also depends on `posthtml-parser` which uses `htmlparser2`. However, looking at the dependency tree:

| Package | htmlparser2 version | entities version | Status |
|---------|---------------------|------------------|--------|
| cheerio@1.0.0 (via juice) | 9.1.0 | ^4.5.0 | ❌ Conflict |
| posthtml-parser@0.12.1 | 7.2.0 | ^3.0.1 | ✓ Works |

`posthtml-parser` uses an older `htmlparser2@7.2.0` which depends on `entities@^3.0.1`. This version still has the `lib/decode.js` path, so it works correctly regardless of hoisting.

The issue specifically comes from `cheerio` (introduced by juice v11) using `htmlparser2@9.1.0`.

## Why This Only Affects Bun

**npm/yarn behavior (works correctly):**
- Uses nested `node_modules` directories
- `htmlparser2` gets its own isolated `entities@4.5.0` in `node_modules/cheerio/node_modules/htmlparser2/node_modules/entities/`
- Each package resolves to the correct version

**Bun behavior (fails by default):**
- Bun uses "hoisted" mode by default, flattening all dependencies to the root `node_modules`
- Only one version of `entities` exists at the top level (v7.0.0 from juice)
- `htmlparser2` resolves to `entities@7.0.0` instead of `entities@4.5.0`
- The import `entities/lib/decode.js` fails because this path doesn't exist in v7.x

This is a known limitation in Bun's default package manager behavior. Related issues:
- [oven-sh/bun#6850](https://github.com/oven-sh/bun/issues/6850) - Support for multiple versions of the same package
- [oven-sh/bun#6608](https://github.com/oven-sh/bun/issues/6608) - Nested overrides not supported

**Note:** Bun users can work around this by using [isolated installs](https://bun.sh/docs/install/isolated) (`bun install --linker isolated`), but this requires manual configuration.

## Alternative Solutions Considered

1. **npm overrides** - Would require nested overrides which Bun doesn't support
2. **Bun isolated installs** (`bun install --linker isolated`) - Works but requires user configuration
3. **Wait for upstream fixes** - `htmlparser2` has an open PR to support `entities` v7 ([fb55/htmlparser2#2215](https://github.com/fb55/htmlparser2/pull/2215))

## Why Downgrade juice?

Downgrading `juice` to `^10.0.1` is the most pragmatic solution because:

- ✅ Works immediately for all users (npm, yarn, pnpm, Bun)
- ✅ No configuration required from users
- ✅ `juice@10.0.1` uses `entities@^4.5.0`, avoiding the version conflict entirely
- ✅ Proven solution (related to #1577)

Once the upstream ecosystem stabilizes (htmlparser2 supporting entities v6+), juice can be upgraded again.

## Changes

```diff
// package.json
- "juice": "^11.1.0",
+ "juice": "^10.0.1",
```

## Related Issues

- #1577 - Similar issue reported previously
- [fb55/htmlparser2#2065](https://github.com/fb55/htmlparser2/issues/2065) - entities v6 compatibility issue
- [fb55/htmlparser2#2215](https://github.com/fb55/htmlparser2/pull/2215) - PR to update entities (still open)