### PR TITLE
feat(build): parallel build across worker threads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "reka-ui": "^2.9.3",
         "string-strip-html": "^13.5.3",
         "tinyglobby": "^0.2.15",
+        "tinypool": "^2.1.0",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3",
         "unplugin-auto-import": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "reka-ui": "^2.9.3",
     "string-strip-html": "^13.5.3",
     "tinyglobby": "^0.2.15",
+    "tinypool": "^2.1.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "unplugin-auto-import": "^21.0.0",

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,16 +1,14 @@
-import { readFileSync, writeFileSync, mkdirSync, cpSync, existsSync, rmSync } from 'node:fs'
-import { resolve, dirname, basename, relative, join, parse as parsePath } from 'node:path'
+import { mkdirSync, cpSync, existsSync, rmSync } from 'node:fs'
+import { resolve, dirname, relative, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { availableParallelism } from 'node:os'
 import { glob } from 'tinyglobby'
 import ora from 'ora'
 import { resolveConfig } from './config/index.ts'
 import { EventManager } from './events/index.ts'
-import { runTransformers } from './transformers/index.ts'
 import { createRenderer } from './render/createRenderer.ts'
-import { createPlaintext } from './plaintext.ts'
-import { stripForHtml, stripForPlaintext } from './utils/output-markers.ts'
 import { normalizeComponentSources } from './utils/componentSources.ts'
-import { _setCurrentTemplate } from './composables/useCurrentTemplate.ts'
-import defu from 'defu'
+import { buildTemplate, computeContentBase } from './render/buildTemplate.ts'
 import type { MaizzleConfig } from './types/index.ts'
 
 export interface BuildResult {
@@ -55,103 +53,47 @@ export async function build(configInput?: Partial<MaizzleConfig> | string): Prom
     rmSync(outputPath, { recursive: true, force: true })
   }
 
-  const renderer = await createRenderer({ markdown: config.markdown, root: config.root, componentDirs: normalizeComponentSources(config.components?.source, process.cwd()), vite: config.vite })
   const outputFiles: string[] = []
+  let droppedAfterBuild = 0
 
-  try {
-    for (const templatePath of templateFiles) {
-      const absolutePath = resolve(templatePath)
-      const parsedPath = parsePath(absolutePath)
-      const template = { source: readFileSync(absolutePath, 'utf-8'), path: parsedPath }
+  const parallel = resolveParallel(config, templateFiles.length, configInput)
 
-      _setCurrentTemplate(parsedPath)
+  if (parallel.enabled) {
+    spinner.text = `Building ${templateFiles.length} templates across ${parallel.workers} workers...`
 
-      try {
-        await events.fireBeforeRender({ config, template })
+    const result = await runParallelBuild({
+      templateFiles,
+      workers: parallel.workers,
+      config,
+      configInput,
+      outputPath,
+      outputExtension,
+      contentBase,
+    })
 
-        const rendered = await renderer.render(absolutePath, config)
-
-        /**
-         * Register SFC event handlers collected during render so they take
-         * part in the post-render events (afterRender / afterTransform).
-         * They're cleared at the end of the iteration so they don't
-         * leak into the next template.
-         */
-        for (const { name, handler } of rendered.sfcEventHandlers) {
-          events.on(name, handler)
-        }
-
-        let html = await events.fireAfterRender({ config, template, html: rendered.html })
-
-        /**
-         * Use the per-template merged config (from defineConfig() in the SFC) so
-         * that template-level overrides like css.safe: false are respected
-         * by transformers.
-         */
-        const templateConfig = rendered.templateConfig
-
-        const doctype = rendered.doctype ?? templateConfig.doctype ?? '<!DOCTYPE html>'
-
-        if (templateConfig.useTransformers !== false) {
-          html = await runTransformers(html, templateConfig, absolutePath, doctype, rendered.tailwindBlocks)
-        }
-
-        html = await events.fireAfterTransform({ config, template, html })
-        if (doctype) html = `${doctype}\n${html}`
-
-        const htmlOut = stripForHtml(html)
-        const sfcOutputPath = rendered.outputPath
-        let outputFilePath: string
-
-        if (sfcOutputPath) {
-          const parsed = parsePath(resolve(sfcOutputPath))
-          const ext = parsed.ext ? parsed.ext.slice(1) : outputExtension
-          outputFilePath = join(parsed.dir, `${parsed.name}.${ext}`)
-        } else {
-          outputFilePath = resolveOutputPath(templatePath, outputPath, outputExtension, contentBase)
-        }
-
-        mkdirSync(dirname(outputFilePath), { recursive: true })
-        writeFileSync(outputFilePath, htmlOut)
-        outputFiles.push(outputFilePath)
-
-        // Generate plaintext version if configured
-        const globalPlaintext = templateConfig.plaintext
-        const sfcPlaintext = rendered.plaintext
-
-        if (globalPlaintext || sfcPlaintext) {
-          const globalCfg = typeof globalPlaintext === 'object' ? globalPlaintext : {}
-          const stripOptions = defu(sfcPlaintext?.options, globalCfg.options)
-          const plaintext = createPlaintext(stripForPlaintext(html), stripOptions)
-          const ptExtension = sfcPlaintext?.extension ?? globalCfg.extension ?? 'txt'
-
-          let ptOutputPath: string
-
-          if (sfcPlaintext?.destination) {
-            const name = basename(templatePath).replace(/\.(vue|md)$/, '')
-            ptOutputPath = join(resolve(sfcPlaintext.destination), `${name}.${ptExtension}`)
-          } else if (sfcOutputPath) {
-            const parsed = parsePath(outputFilePath)
-            ptOutputPath = join(parsed.dir, `${parsed.name}.${ptExtension}`)
-          } else if (globalCfg.destination) {
-            ptOutputPath = resolveOutputPath(templatePath, resolve(globalCfg.destination), ptExtension, contentBase)
-          } else {
-            ptOutputPath = resolveOutputPath(templatePath, outputPath, ptExtension, contentBase)
-          }
-
-          mkdirSync(dirname(ptOutputPath), { recursive: true })
-          writeFileSync(ptOutputPath, plaintext)
-        }
-      } finally {
-        _setCurrentTemplate(undefined)
-        events.clearSfcHandlers()
-      }
-    }
+    outputFiles.push(...result.files)
+    droppedAfterBuild = result.sfcAfterBuildCount
 
     await copyStatic(config, outputPath)
     await events.fireAfterBuild({ files: outputFiles, config })
-  } finally {
-    await renderer.close()
+  } else {
+    const renderer = await createRenderer({ markdown: config.markdown, root: config.root, componentDirs: normalizeComponentSources(config.components?.source, process.cwd()), vite: config.vite })
+
+    try {
+      for (const templatePath of templateFiles) {
+        const { files } = await buildTemplate(templatePath, { config, renderer, events, outputPath, outputExtension, contentBase })
+        outputFiles.push(...files)
+      }
+
+      await copyStatic(config, outputPath)
+      await events.fireAfterBuild({ files: outputFiles, config })
+    } finally {
+      await renderer.close()
+    }
+  }
+
+  if (droppedAfterBuild > 0) {
+    console.warn(`[maizzle] Skipped ${droppedAfterBuild} SFC-registered afterBuild handler(s): afterBuild can't run inside a parallel build worker. Move build-completion logic to the config's afterBuild hook.`)
   }
 
   const duration = ((Date.now() - start) / 1000).toFixed(2)
@@ -165,30 +107,118 @@ export async function build(configInput?: Partial<MaizzleConfig> | string): Prom
 }
 
 /**
- * Extract the static (non-glob) prefix from content patterns.
- *
- * For example, `['/abs/path/emails/**\/*.vue']` → `'/abs/path/emails'`
- *
- * This is used to strip the content base from template paths
- * so the output preserves only the subdirectory structure.
+ * Default template count above which parallel build turns on. Benchmarked
+ * crossover (with the worker cap below) is ~25 templates; 50 leaves margin so
+ * auto-parallel only kicks in where it's a reliable win across hardware.
+ * Override per project with `parallel: { threshold }`.
  */
-function computeContentBase(patterns: string[]): string {
-  // Use the first non-negated pattern
-  const pattern = patterns.find(p => !p.startsWith('!')) ?? patterns[0]
+const DEFAULT_PARALLEL_THRESHOLD = 50
 
-  // Split on first glob character (* { ? [) and take the directory part
-  const staticPart = pattern.split(/[*{?[]/)[0]
+/**
+ * Default worker cap. Each worker runs a full Vite SSR renderer, so startup +
+ * contention outweighs added parallelism past ~8 — benchmarks showed 8 beating
+ * 12/16/23 at every size. Override with `parallel: { workers }`.
+ */
+const DEFAULT_MAX_WORKERS = 8
 
-  // Ensure we have a clean directory path (not a partial segment)
-  return resolve(staticPart.endsWith('/') ? staticPart : dirname(staticPart))
+/**
+ * Decide whether to build in parallel and with how many workers.
+ *
+ * `config.parallel`:
+ *   - omitted → parallel when `count > 50`, min(CPU count − 1, 8) workers
+ *   - `true`  → always parallel (ignores threshold), default workers
+ *   - `false` → always sequential
+ *   - `{ workers, threshold }` → parallel when `count > threshold` (default 50),
+ *     using `workers` threads (default min(CPU count − 1, 8))
+ *
+ * Workers reload the config file to recover function hooks, so parallel only
+ * applies to file-based configs (a path or the default cwd config) — an inline
+ * config object has no file to reload and always builds sequentially.
+ */
+export function resolveParallel(
+  config: MaizzleConfig,
+  count: number,
+  configInput: Partial<MaizzleConfig> | string | undefined,
+): { enabled: boolean; workers: number } {
+  const setting = config.parallel
+  if (setting === false) return { enabled: false, workers: 0 }
+
+  const fileBased = typeof configInput === 'string' || configInput == null
+  if (!fileBased) return { enabled: false, workers: 0 }
+
+  const cpus = availableParallelism()
+  const defaultWorkers = Math.min(Math.max(1, cpus - 1), DEFAULT_MAX_WORKERS)
+
+  let maxWorkers = defaultWorkers
+  let threshold = DEFAULT_PARALLEL_THRESHOLD
+  // `true` opts in regardless of count; object/omitted stay threshold-gated.
+  const ignoreThreshold = setting === true
+
+  if (typeof setting === 'object' && setting !== null) {
+    if (typeof setting.workers === 'number' && setting.workers > 0) maxWorkers = Math.floor(setting.workers)
+    if (typeof setting.threshold === 'number' && setting.threshold >= 0) threshold = Math.floor(setting.threshold)
+  }
+
+  if (!ignoreThreshold && count <= threshold) return { enabled: false, workers: 0 }
+
+  const workers = Math.min(maxWorkers, count)
+  return { enabled: workers >= 2 && count >= 2, workers }
 }
 
-function resolveOutputPath(templatePath: string, outputDir: string, extension: string, contentBase: string): string {
-  const name = basename(templatePath).replace(/\.(vue|md)$/, '')
-  const absTemplate = resolve(templatePath)
-  const rel = relative(contentBase, dirname(absTemplate))
+/**
+ * Run the build across worker threads. Each worker reloads the config (for its
+ * function hooks), builds its batch via the same `buildTemplate` as the
+ * sequential path, and returns the files it wrote. beforeCreate/afterBuild stay
+ * on the main thread (handled by the caller).
+ */
+async function runParallelBuild(opts: {
+  templateFiles: string[]
+  workers: number
+  config: MaizzleConfig
+  configInput: Partial<MaizzleConfig> | string | undefined
+  outputPath: string
+  outputExtension: string
+  contentBase: string
+}): Promise<{ files: string[]; sfcAfterBuildCount: number }> {
+  const { templateFiles, workers, config, configInput, outputPath, outputExtension, contentBase } = opts
 
-  return join(outputDir, rel, `${name}.${extension}`)
+  const { default: Tinypool } = await import('tinypool')
+  const workerPath = resolve(dirname(fileURLToPath(import.meta.url)), 'render/parallel/worker.mjs')
+
+  const configPath = typeof configInput === 'string' ? configInput : undefined
+  // Serializable snapshot of the post-beforeCreate config (functions dropped).
+  const configData = JSON.parse(JSON.stringify(config)) as Partial<MaizzleConfig>
+
+  const batches = shardEvenly(templateFiles, workers)
+
+  const pool = new Tinypool({ filename: workerPath, minThreads: batches.length, maxThreads: batches.length })
+
+  try {
+    const results = await Promise.all(
+      batches.map(templatePaths => pool.run({
+        templatePaths,
+        configPath,
+        configData,
+        outputPath,
+        outputExtension,
+        contentBase,
+      })),
+    )
+
+    return {
+      files: results.flatMap(r => r.files),
+      sfcAfterBuildCount: results.reduce((n, r) => n + r.sfcAfterBuildCount, 0),
+    }
+  } finally {
+    await pool.destroy()
+  }
+}
+
+/** Round-robin items into up to `buckets` non-empty groups for even balance. */
+function shardEvenly<T>(items: T[], buckets: number): T[][] {
+  const out: T[][] = Array.from({ length: buckets }, () => [])
+  items.forEach((item, i) => out[i % buckets].push(item))
+  return out.filter(b => b.length > 0)
 }
 
 async function copyStatic(config: MaizzleConfig, outputPath: string): Promise<void> {

--- a/src/render/buildTemplate.ts
+++ b/src/render/buildTemplate.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
-import { resolve, dirname, basename, relative, join, parse as parsePath } from 'node:path'
+import { resolve, dirname, basename, relative, join, sep, parse as parsePath } from 'node:path'
 import defu from 'defu'
 import { runTransformers } from '../transformers/index.ts'
 import { createPlaintext } from '../plaintext.ts'
@@ -120,8 +120,7 @@ export async function buildTemplate(
       let ptOutputPath: string
 
       if (sfcPlaintext?.destination) {
-        const name = basename(templatePath).replace(/\.(vue|md)$/, '')
-        ptOutputPath = join(resolve(sfcPlaintext.destination), `${name}.${ptExtension}`)
+        ptOutputPath = resolveOutputPath(templatePath, resolve(sfcPlaintext.destination), ptExtension, contentBase)
       } else if (sfcOutputPath) {
         const parsed = parsePath(outputFilePath)
         ptOutputPath = join(parsed.dir, `${parsed.name}.${ptExtension}`)
@@ -149,16 +148,36 @@ export async function buildTemplate(
  *
  * Used to strip the content base from template paths so the output preserves
  * only the subdirectory structure.
+ *
+ * With multiple positive patterns (multi-root setups), returns their common
+ * ancestor directory so templates from every root keep a clean relative path.
  */
 export function computeContentBase(patterns: string[]): string {
-  // Use the first non-negated pattern
-  const pattern = patterns.find(p => !p.startsWith('!')) ?? patterns[0]
+  const positives = patterns.filter(p => !p.startsWith('!'))
+  const sources = positives.length > 0 ? positives : patterns
 
-  // Split on first glob character (* { ? [) and take the directory part
-  const staticPart = pattern.split(/[*{?[]/)[0]
+  const bases = sources.map((pattern) => {
+    // Split on first glob character (* { ? [) and take the directory part
+    const staticPart = pattern.split(/[*{?[]/)[0]
+    // Ensure we have a clean directory path (not a partial segment)
+    return resolve(staticPart.endsWith('/') ? staticPart : dirname(staticPart))
+  })
 
-  // Ensure we have a clean directory path (not a partial segment)
-  return resolve(staticPart.endsWith('/') ? staticPart : dirname(staticPart))
+  return bases.reduce(commonPath)
+}
+
+/** Longest common directory path shared by two absolute paths. */
+function commonPath(a: string, b: string): string {
+  const aSegments = a.split(sep)
+  const bSegments = b.split(sep)
+  const shared: string[] = []
+
+  for (let i = 0; i < Math.min(aSegments.length, bSegments.length); i++) {
+    if (aSegments[i] !== bSegments[i]) break
+    shared.push(aSegments[i])
+  }
+
+  return shared.join(sep) || sep
 }
 
 export function resolveOutputPath(templatePath: string, outputDir: string, extension: string, contentBase: string): string {

--- a/src/render/buildTemplate.ts
+++ b/src/render/buildTemplate.ts
@@ -79,16 +79,17 @@ export async function buildTemplate(
       events.on(name, handler)
     }
 
-    let html = await events.fireAfterRender({ config: renderConfig, template, html: rendered.html })
-
     const templateConfig = rendered.templateConfig
+
+    let html = await events.fireAfterRender({ config: templateConfig, template, html: rendered.html })
+
     const doctype = rendered.doctype ?? templateConfig.doctype ?? '<!DOCTYPE html>'
 
     if (templateConfig.useTransformers !== false) {
       html = await runTransformers(html, templateConfig, absolutePath, doctype, rendered.tailwindBlocks)
     }
 
-    html = await events.fireAfterTransform({ config: renderConfig, template, html })
+    html = await events.fireAfterTransform({ config: templateConfig, template, html })
     if (doctype) html = `${doctype}\n${html}`
 
     const htmlOut = stripForHtml(html)

--- a/src/render/buildTemplate.ts
+++ b/src/render/buildTemplate.ts
@@ -1,0 +1,170 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { resolve, dirname, basename, relative, join, parse as parsePath } from 'node:path'
+import defu from 'defu'
+import { runTransformers } from '../transformers/index.ts'
+import { createPlaintext } from '../plaintext.ts'
+import { stripForHtml, stripForPlaintext } from '../utils/output-markers.ts'
+import { _setCurrentTemplate } from '../composables/useCurrentTemplate.ts'
+import type { EventManager } from '../events/index.ts'
+import type { Renderer } from './createRenderer.ts'
+import type { MaizzleConfig } from '../types/index.ts'
+
+export interface BuildTemplateContext {
+  config: MaizzleConfig
+  renderer: Renderer
+  events: EventManager
+  outputPath: string
+  outputExtension: string
+  contentBase: string
+}
+
+export interface BuildTemplateResult {
+  /** Output files written for this template (html + optional plaintext). */
+  files: string[]
+  /**
+   * Number of SFC-registered `afterBuild` handlers seen while rendering. They
+   * only fire once at end of build on the main thread, so a worker can't run
+   * them — the count lets the orchestrator warn instead of silently dropping.
+   */
+  sfcAfterBuildCount: number
+}
+
+/**
+ * Render a single template through the full pipeline and write its output.
+ *
+ * Shared by the sequential build loop and the parallel build worker so both
+ * paths produce byte-identical output. `events` is the manager the per-template
+ * events fire on (config handlers registered via `registerConfig`, SFC handlers
+ * registered here from the render). The caller owns build-scoped events
+ * (`beforeCreate`/`afterBuild`).
+ */
+export async function buildTemplate(
+  templatePath: string,
+  ctx: BuildTemplateContext,
+): Promise<BuildTemplateResult> {
+  const { config, renderer, events, outputPath, outputExtension, contentBase } = ctx
+  const absolutePath = resolve(templatePath)
+  const parsedPath = parsePath(absolutePath)
+  const template = { source: readFileSync(absolutePath, 'utf-8'), path: parsedPath }
+  const files: string[] = []
+  let sfcAfterBuildCount = 0
+
+  _setCurrentTemplate(parsedPath)
+
+  try {
+    /**
+     * Clone config per template so beforeRender mutations (setting a
+     * preheader, injecting fetched data, etc.) stay scoped to this template
+     * instead of leaking into later ones through the shared config object.
+     */
+    const renderConfig = defu({}, config) as MaizzleConfig
+    const originalSource = template.source
+
+    await events.fireBeforeRender({ config: renderConfig, template })
+
+    const rendered = await renderer.render(
+      absolutePath,
+      renderConfig,
+      template.source !== originalSource ? { source: template.source } : undefined,
+    )
+
+    /**
+     * Register SFC event handlers collected during render so they take part in
+     * the post-render events. Cleared at the end of this call so they don't
+     * leak into the next template (afterBuild is the exception — it's never
+     * cleared by clearSfcHandlers; see the count above).
+     */
+    for (const { name, handler } of rendered.sfcEventHandlers) {
+      if (name === 'afterBuild') sfcAfterBuildCount++
+      events.on(name, handler)
+    }
+
+    let html = await events.fireAfterRender({ config: renderConfig, template, html: rendered.html })
+
+    const templateConfig = rendered.templateConfig
+    const doctype = rendered.doctype ?? templateConfig.doctype ?? '<!DOCTYPE html>'
+
+    if (templateConfig.useTransformers !== false) {
+      html = await runTransformers(html, templateConfig, absolutePath, doctype, rendered.tailwindBlocks)
+    }
+
+    html = await events.fireAfterTransform({ config: renderConfig, template, html })
+    if (doctype) html = `${doctype}\n${html}`
+
+    const htmlOut = stripForHtml(html)
+    const sfcOutputPath = rendered.outputPath
+    let outputFilePath: string
+
+    if (sfcOutputPath) {
+      const parsed = parsePath(resolve(sfcOutputPath))
+      const ext = parsed.ext ? parsed.ext.slice(1) : outputExtension
+      outputFilePath = join(parsed.dir, `${parsed.name}.${ext}`)
+    } else {
+      outputFilePath = resolveOutputPath(templatePath, outputPath, outputExtension, contentBase)
+    }
+
+    mkdirSync(dirname(outputFilePath), { recursive: true })
+    writeFileSync(outputFilePath, htmlOut)
+    files.push(outputFilePath)
+
+    // Generate plaintext version if configured
+    const globalPlaintext = templateConfig.plaintext
+    const sfcPlaintext = rendered.plaintext
+
+    if (globalPlaintext || sfcPlaintext) {
+      const globalCfg = typeof globalPlaintext === 'object' ? globalPlaintext : {}
+      const stripOptions = defu(sfcPlaintext?.options, globalCfg.options)
+      const plaintext = createPlaintext(stripForPlaintext(html), stripOptions)
+      const ptExtension = sfcPlaintext?.extension ?? globalCfg.extension ?? 'txt'
+
+      let ptOutputPath: string
+
+      if (sfcPlaintext?.destination) {
+        const name = basename(templatePath).replace(/\.(vue|md)$/, '')
+        ptOutputPath = join(resolve(sfcPlaintext.destination), `${name}.${ptExtension}`)
+      } else if (sfcOutputPath) {
+        const parsed = parsePath(outputFilePath)
+        ptOutputPath = join(parsed.dir, `${parsed.name}.${ptExtension}`)
+      } else if (globalCfg.destination) {
+        ptOutputPath = resolveOutputPath(templatePath, resolve(globalCfg.destination), ptExtension, contentBase)
+      } else {
+        ptOutputPath = resolveOutputPath(templatePath, outputPath, ptExtension, contentBase)
+      }
+
+      mkdirSync(dirname(ptOutputPath), { recursive: true })
+      writeFileSync(ptOutputPath, plaintext)
+    }
+  } finally {
+    _setCurrentTemplate(undefined)
+    events.clearSfcHandlers()
+  }
+
+  return { files, sfcAfterBuildCount }
+}
+
+/**
+ * Extract the static (non-glob) prefix from content patterns.
+ *
+ * For example, `['/abs/path/emails/**\/*.vue']` → `'/abs/path/emails'`
+ *
+ * Used to strip the content base from template paths so the output preserves
+ * only the subdirectory structure.
+ */
+export function computeContentBase(patterns: string[]): string {
+  // Use the first non-negated pattern
+  const pattern = patterns.find(p => !p.startsWith('!')) ?? patterns[0]
+
+  // Split on first glob character (* { ? [) and take the directory part
+  const staticPart = pattern.split(/[*{?[]/)[0]
+
+  // Ensure we have a clean directory path (not a partial segment)
+  return resolve(staticPart.endsWith('/') ? staticPart : dirname(staticPart))
+}
+
+export function resolveOutputPath(templatePath: string, outputDir: string, extension: string, contentBase: string): string {
+  const name = basename(templatePath).replace(/\.(vue|md)$/, '')
+  const absTemplate = resolve(templatePath)
+  const rel = relative(contentBase, dirname(absTemplate))
+
+  return join(outputDir, rel, `${name}.${extension}`)
+}

--- a/src/render/createRenderer.ts
+++ b/src/render/createRenderer.ts
@@ -44,7 +44,7 @@ export interface RenderedTemplate {
 }
 
 export interface Renderer {
-  render(input: string | Component, config: MaizzleConfig): Promise<RenderedTemplate>
+  render(input: string | Component, config: MaizzleConfig, opts?: { source?: string }): Promise<RenderedTemplate>
   invalidate(filePath: string): Promise<void>
   invalidateAll(): Promise<void>
   close(): Promise<void>
@@ -224,6 +224,15 @@ export async function createRenderer(
   let virtualSfcSource = ''
 
   /**
+   * Per-render source overrides keyed by absolute template path. Lets the
+   * build's beforeRender event rewrite a template's source before compile
+   * while keeping the real file id — so relative imports, asset URLs and
+   * component resolution still resolve against the actual file location
+   * (which the virtual-SFC path can't do).
+   */
+  const sourceOverrides = new Map<string, string>()
+
+  /**
    * Never load the host project's vite.config.ts here. Doing so pulls
    * every host plugin (Nitro, TanStack Start, the Maizzle plugin
    * itself, …) into this isolated SSR pipeline, where they override
@@ -245,6 +254,13 @@ export async function createRenderer(
         },
         load(id) {
           if (id === VIRTUAL_SFC_ID) return virtualSfcSource
+        },
+      },
+      {
+        name: 'maizzle:source-override',
+        load(id) {
+          const override = sourceOverrides.get(id.split('?')[0])
+          if (override !== undefined) return override
         },
       },
       vue({
@@ -375,7 +391,7 @@ export async function createRenderer(
   const server = await createServer(finalConfig)
 
   return {
-    async render(input: string | Component, config: MaizzleConfig): Promise<RenderedTemplate> {
+    async render(input: string | Component, config: MaizzleConfig, opts?: { source?: string }): Promise<RenderedTemplate> {
       let component: Component
       let configKey: InjectionKey<MaizzleConfig>
       let contextKey: InjectionKey<RenderContext>
@@ -396,7 +412,27 @@ export async function createRenderer(
           if (mod) server.moduleGraph.invalidateModule(mod)
           component = (await server.ssrLoadModule(VIRTUAL_SFC_ID)).default
         } else {
-          component = (await server.ssrLoadModule(input)).default
+          /**
+           * A beforeRender handler may have rewritten the source. Register it
+           * under the real path id and invalidate so ssrLoadModule compiles
+           * the override; clear + invalidate afterwards so the override never
+           * leaks into a later render of the same path.
+           */
+          const hasOverride = opts?.source !== undefined
+          if (hasOverride) {
+            sourceOverrides.set(input, opts!.source!)
+            const mod = await server.moduleGraph.getModuleByUrl(input)
+            if (mod) server.moduleGraph.invalidateModule(mod)
+          }
+          try {
+            component = (await server.ssrLoadModule(input)).default
+          } finally {
+            if (hasOverride) {
+              sourceOverrides.delete(input)
+              const mod = await server.moduleGraph.getModuleByUrl(input)
+              if (mod) server.moduleGraph.invalidateModule(mod)
+            }
+          }
         }
       } else {
         // Pre-compiled component — use directly imported keys

--- a/src/render/parallel/buildWorker.ts
+++ b/src/render/parallel/buildWorker.ts
@@ -1,4 +1,4 @@
-import defu from 'defu'
+import { createDefu } from 'defu'
 import { resolveConfig } from '../../config/index.ts'
 import { createRenderer } from '../createRenderer.ts'
 import { EventManager } from '../../events/index.ts'
@@ -24,6 +24,18 @@ export interface BuildWorkerResult {
 }
 
 /**
+ * Overlay config data with array-replace (not defu's default concat) so the
+ * main thread's arrays — content globs, plugin/source lists — fully replace the
+ * reloaded config's instead of duplicating every entry.
+ */
+const mergeConfig = createDefu((obj, key, value) => {
+  if (Array.isArray(value)) {
+    if (!(key in obj)) obj[key as keyof typeof obj] = value
+    return true
+  }
+})
+
+/**
  * Build one batch of templates in a worker thread.
  *
  * Config function hooks (beforeRender/afterRender/afterTransform) can't cross
@@ -37,7 +49,7 @@ export async function run(data: BuildWorkerData): Promise<BuildWorkerResult> {
   const { templatePaths, configPath, configData, outputPath, outputExtension, contentBase } = data
 
   const reloaded = await resolveConfig(configPath)
-  const config = defu(configData, reloaded) as MaizzleConfig
+  const config = mergeConfig(configData, reloaded) as MaizzleConfig
 
   const events = new EventManager()
   events.registerConfig(config)

--- a/src/render/parallel/buildWorker.ts
+++ b/src/render/parallel/buildWorker.ts
@@ -1,0 +1,73 @@
+import defu from 'defu'
+import { resolveConfig } from '../../config/index.ts'
+import { createRenderer } from '../createRenderer.ts'
+import { EventManager } from '../../events/index.ts'
+import { normalizeComponentSources } from '../../utils/componentSources.ts'
+import { buildTemplate } from '../buildTemplate.ts'
+import type { MaizzleConfig } from '../../types/index.ts'
+
+export interface BuildWorkerData {
+  /** Template paths (glob-relative, as produced on the main thread) for this batch. */
+  templatePaths: string[]
+  /** Config file path to reload (undefined → load maizzle.config from cwd). */
+  configPath?: string
+  /** Serialized, post-beforeCreate config data from the main thread. */
+  configData: Partial<MaizzleConfig>
+  outputPath: string
+  outputExtension: string
+  contentBase: string
+}
+
+export interface BuildWorkerResult {
+  files: string[]
+  sfcAfterBuildCount: number
+}
+
+/**
+ * Build one batch of templates in a worker thread.
+ *
+ * Config function hooks (beforeRender/afterRender/afterTransform) can't cross
+ * the thread boundary, so the worker reloads the config module to recover them,
+ * then overlays the main thread's serialized config DATA on top — so
+ * beforeCreate mutations and resolved values win while the reloaded config only
+ * backfills the lost functions. beforeCreate/afterBuild are owned by the main
+ * thread and never run here.
+ */
+export async function run(data: BuildWorkerData): Promise<BuildWorkerResult> {
+  const { templatePaths, configPath, configData, outputPath, outputExtension, contentBase } = data
+
+  const reloaded = await resolveConfig(configPath)
+  const config = defu(configData, reloaded) as MaizzleConfig
+
+  const events = new EventManager()
+  events.registerConfig(config)
+
+  const renderer = await createRenderer({
+    markdown: config.markdown,
+    root: config.root,
+    componentDirs: normalizeComponentSources(config.components?.source, process.cwd()),
+    vite: config.vite,
+  })
+
+  const files: string[] = []
+  let sfcAfterBuildCount = 0
+
+  try {
+    for (const templatePath of templatePaths) {
+      const result = await buildTemplate(templatePath, {
+        config,
+        renderer,
+        events,
+        outputPath,
+        outputExtension,
+        contentBase,
+      })
+      files.push(...result.files)
+      sfcAfterBuildCount += result.sfcAfterBuildCount
+    }
+  } finally {
+    await renderer.close()
+  }
+
+  return { files, sfcAfterBuildCount }
+}

--- a/src/render/parallel/worker.mjs
+++ b/src/render/parallel/worker.mjs
@@ -1,0 +1,28 @@
+// Tinypool worker entry. Plain JS so it loads in a raw worker thread without a
+// TS toolchain. In the published dist the implementation is already compiled to
+// `.js` and is imported natively (fast); during dev/tests only the `.ts` source
+// exists and is loaded through jiti.
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { existsSync } from 'node:fs'
+
+let implPromise
+
+function loadImpl() {
+  if (!implPromise) {
+    const jsPath = fileURLToPath(new URL('./buildWorker.js', import.meta.url))
+    if (existsSync(jsPath)) {
+      implPromise = import(pathToFileURL(jsPath).href)
+    } else {
+      const tsPath = fileURLToPath(new URL('./buildWorker.ts', import.meta.url))
+      implPromise = import('jiti').then(({ createJiti }) =>
+        createJiti(fileURLToPath(import.meta.url)).import(tsPath),
+      )
+    }
+  }
+  return implPromise
+}
+
+export default async function buildWorker(data) {
+  const impl = await loadImpl()
+  return impl.run(data)
+}

--- a/src/tests/build.test.ts
+++ b/src/tests/build.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir, availableParallelism } from 'node:os'
 import { build, resolveParallel } from '../build.ts'
+import { computeContentBase } from '../render/buildTemplate.ts'
 
 function createTempProject() {
   const dir = mkdtempSync(join(tmpdir(), 'maizzle-build-'))
@@ -345,6 +346,38 @@ describe('build', () => {
 
     // afterBuild ran once on the main thread with the full file list
     expect(readFileSync(marker, 'utf-8')).toBe('4')
+  }, 120_000)
+
+  it('warns about SFC-registered afterBuild handlers dropped in a parallel build', async () => {
+    for (let i = 1; i <= 2; i++) {
+      writeSfc(tempDir, `emails/w${i}.vue`, `
+        <script setup>
+          useEvent('afterBuild', () => {})
+        </script>
+        <template>
+          <div>Template ${i}</div>
+        </template>
+      `)
+    }
+
+    writeFileSync(join(tempDir, 'maizzle.config.js'), `
+      export default {
+        parallel: { workers: 2, threshold: 0 }
+      }
+    `)
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    let calls: unknown[][]
+    try {
+      await build()
+    } finally {
+      // Capture before restoring — mockRestore() clears the recorded calls.
+      calls = warn.mock.calls.slice()
+      warn.mockRestore()
+    }
+
+    expect(calls.some(c => String(c[0]).includes("afterBuild can't run inside a parallel build worker"))).toBe(true)
   }, 120_000)
 
   it('fires beforeCreate to modify config', async () => {
@@ -867,5 +900,28 @@ describe('resolveParallel', () => {
 
   it('stays sequential for inline-object configs (no file to reload hooks from)', () => {
     expect(resolveParallel({ parallel: true }, 100, {}).enabled).toBe(false)
+  })
+})
+
+describe('computeContentBase', () => {
+  it('derives the static directory from a single glob pattern', () => {
+    expect(computeContentBase(['emails/**/*.vue'])).toBe(join(process.cwd(), 'emails'))
+  })
+
+  it('keeps a trailing-slash static part as-is', () => {
+    expect(computeContentBase(['emails/*.vue'])).toBe(join(process.cwd(), 'emails'))
+  })
+
+  it('returns the common ancestor of multiple positive patterns', () => {
+    expect(computeContentBase(['src/emails/**/*.vue', 'src/newsletters/**/*.vue']))
+      .toBe(join(process.cwd(), 'src'))
+  })
+
+  it('ignores negated patterns when computing the base', () => {
+    expect(computeContentBase(['emails/**/*.vue', '!emails/partials/**'])).toBe(join(process.cwd(), 'emails'))
+  })
+
+  it('falls back to all patterns when every pattern is negated', () => {
+    expect(computeContentBase(['!emails/**/*.vue'])).toBe(join(process.cwd(), '!emails'))
   })
 })

--- a/src/tests/build.test.ts
+++ b/src/tests/build.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs'
 import { join } from 'node:path'
-import { tmpdir } from 'node:os'
-import { build } from '../build.ts'
+import { tmpdir, availableParallelism } from 'node:os'
+import { build, resolveParallel } from '../build.ts'
 
 function createTempProject() {
   const dir = mkdtempSync(join(tmpdir(), 'maizzle-build-'))
@@ -149,6 +149,66 @@ describe('build', () => {
     delete (globalThis as any).__beforeRenderFired
   })
 
+  it('compiles the source returned from beforeRender', async () => {
+    writeSfc(tempDir, 'emails/test.vue', `
+      <template>
+        <div>ORIGINAL</div>
+      </template>
+    `)
+
+    writeFileSync(join(tempDir, 'maizzle.config.js'), `
+      export default {
+        beforeRender({ template }) {
+          return template.source.replace('ORIGINAL', 'REWRITTEN')
+        }
+      }
+    `)
+
+    const result = await build()
+    const html = readFileSync(result.files[0], 'utf-8')
+
+    expect(html).toContain('REWRITTEN')
+    expect(html).not.toContain('ORIGINAL')
+  })
+
+  it('uses beforeRender config mutations during compile, scoped per template', async () => {
+    writeSfc(tempDir, 'emails/a.vue', `
+      <script setup>
+        const config = useConfig()
+      </script>
+      <template>
+        <div>{{ config.greeting }}</div>
+      </template>
+    `)
+
+    writeSfc(tempDir, 'emails/b.vue', `
+      <script setup>
+        const config = useConfig()
+      </script>
+      <template>
+        <div>{{ config.greeting ?? 'none' }}</div>
+      </template>
+    `)
+
+    writeFileSync(join(tempDir, 'maizzle.config.js'), `
+      export default {
+        beforeRender({ template, config }) {
+          if (template.path.name === 'a') config.greeting = 'AAA'
+        }
+      }
+    `)
+
+    const result = await build()
+    const aHtml = readFileSync(result.files.find(f => f.includes('a.html'))!, 'utf-8')
+    const bHtml = readFileSync(result.files.find(f => f.includes('b.html'))!, 'utf-8')
+
+    // 'a' sees its own mutation
+    expect(aHtml).toContain('AAA')
+    // 'b' must NOT inherit 'a's mutation (per-template config clone)
+    expect(bHtml).not.toContain('AAA')
+    expect(bHtml).toContain('none')
+  })
+
   it('fires afterRender event and uses modified HTML', async () => {
     writeSfc(tempDir, 'emails/test.vue', `
       <template>
@@ -215,6 +275,77 @@ describe('build', () => {
     const content = readFileSync(marker, 'utf-8')
     expect(content).toContain('test.html')
   })
+
+  it('builds every template when experimental.parallel is set', async () => {
+    for (let i = 1; i <= 6; i++) {
+      writeSfc(tempDir, `emails/t${i}.vue`, `
+        <template>
+          <div>Template ${i}</div>
+        </template>
+      `)
+    }
+
+    writeFileSync(join(tempDir, 'maizzle.config.js'), `
+      export default {
+        parallel: { workers: 2, threshold: 0 }
+      }
+    `)
+
+    const result = await build()
+
+    expect(result.files).toHaveLength(6)
+    for (let i = 1; i <= 6; i++) {
+      const file = result.files.find(p => p.includes(`t${i}.html`))
+      expect(file, `output for t${i}`).toBeDefined()
+      expect(readFileSync(file!, 'utf-8')).toContain(`Template ${i}`)
+    }
+  }, 120_000)
+
+  it('runs config events and afterBuild during a parallel build', async () => {
+    for (let i = 1; i <= 4; i++) {
+      writeSfc(tempDir, `emails/e${i}.vue`, `
+        <script setup>
+          const config = useConfig()
+        </script>
+        <template>
+          <div>{{ config.injected }}|PLACEHOLDER</div>
+        </template>
+      `)
+    }
+
+    const marker = join(tempDir, 'afterbuild.count')
+
+    writeFileSync(join(tempDir, 'maizzle.config.js'), `
+      import { writeFileSync } from 'node:fs'
+
+      export default {
+        parallel: { workers: 2, threshold: 0 },
+        beforeRender({ template, config }) {
+          config.injected = 'IN-' + template.path.name
+        },
+        afterRender({ html }) {
+          return html.replace('PLACEHOLDER', 'AR')
+        },
+        afterBuild({ files }) {
+          writeFileSync('${marker.replace(/\\/g, '\\\\')}', String(files.length))
+        }
+      }
+    `)
+
+    const result = await build()
+
+    expect(result.files).toHaveLength(4)
+
+    const e1 = readFileSync(result.files.find(p => p.includes('e1.html'))!, 'utf-8')
+    // beforeRender config mutation reached compile (in the worker)
+    expect(e1).toContain('IN-e1')
+    // afterRender transform ran (in the worker)
+    expect(e1).toContain('AR')
+    expect(e1).not.toContain('PLACEHOLDER')
+
+    // afterBuild ran once on the main thread with the full file list
+    expect(readFileSync(marker, 'utf-8')).toBe('4')
+  }, 120_000)
 
   it('fires beforeCreate to modify config', async () => {
     writeSfc(tempDir, 'emails/test.vue', `
@@ -687,5 +818,54 @@ describe('build', () => {
     const result = await build({ content: ['!emails/skip.vue'] })
 
     expect(result.files).toHaveLength(0)
+  })
+})
+
+describe('resolveParallel', () => {
+  const defaultWorkers = Math.min(Math.max(1, availableParallelism() - 1), 8)
+
+  it('is off by default at or below 50 templates', () => {
+    expect(resolveParallel({}, 50, undefined).enabled).toBe(false)
+  })
+
+  it('turns on by default above 50 templates (file-based config)', () => {
+    const result = resolveParallel({}, 51, undefined)
+    expect(result.enabled).toBe(defaultWorkers >= 2)
+    if (result.enabled) expect(result.workers).toBe(defaultWorkers)
+  })
+
+  it('gates on a custom threshold', () => {
+    expect(resolveParallel({ parallel: { threshold: 100 } }, 100, undefined).enabled).toBe(false)
+    expect(resolveParallel({ parallel: { threshold: 100 } }, 101, undefined).enabled).toBe(defaultWorkers >= 2)
+  })
+
+  it('threshold 0 always parallelizes (given ≥2 templates)', () => {
+    expect(resolveParallel({ parallel: { workers: 2, threshold: 0 } }, 4, undefined)).toEqual({ enabled: true, workers: 2 })
+  })
+
+  it('caps the default worker count at 8 regardless of CPU count', () => {
+    expect(resolveParallel({ parallel: true }, 1000, undefined).workers).toBeLessThanOrEqual(8)
+  })
+
+  it('lets an explicit worker count exceed the default cap', () => {
+    expect(resolveParallel({ parallel: { workers: 16, threshold: 0 } }, 100, undefined)).toEqual({ enabled: true, workers: 16 })
+  })
+
+  it('caps workers at the template count', () => {
+    expect(resolveParallel({ parallel: { workers: 8, threshold: 0 } }, 3, undefined)).toEqual({ enabled: true, workers: 3 })
+  })
+
+  it('true opts in below the default threshold', () => {
+    const result = resolveParallel({ parallel: true }, 4, undefined)
+    const expected = Math.min(defaultWorkers, 4)
+    expect(result.enabled).toBe(expected >= 2)
+  })
+
+  it('stays sequential when parallel is false', () => {
+    expect(resolveParallel({ parallel: false }, 1000, undefined).enabled).toBe(false)
+  })
+
+  it('stays sequential for inline-object configs (no file to reload hooks from)', () => {
+    expect(resolveParallel({ parallel: true }, 100, {}).enabled).toBe(false)
   })
 })

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -539,6 +539,24 @@ export interface MaizzleConfig {
      */
     extension?: string
   }
+  /**
+   * Build templates in parallel across worker threads.
+   *
+   * - omitted (default): parallel when there are more than 50 templates
+   * - `true`: always parallel, using min(CPU count − 1, 8) workers
+   * - `false`: always sequential
+   * - `{ workers, threshold }`: parallel when the template count exceeds
+   *   `threshold` (default 50), using `workers` threads (default
+   *   min(CPU count − 1, 8)). Set `threshold: 0` to always parallelize.
+   *
+   * Note: more workers is not faster — each runs a full renderer, so ~8 is the
+   * sweet spot and over-provisioning slows builds down.
+   *
+   * Only applies to file-based configs (the CLI / a config path); an inline
+   * config object always builds sequentially. SFC-registered `afterBuild`
+   * handlers can't run in a worker — use the config `afterBuild` hook instead.
+   */
+  parallel?: boolean | { workers?: number; threshold?: number }
   /** Static file copying configuration. */
   static?: {
     /**

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -21,6 +21,8 @@ export default defineConfig({
       cpSync('src/components', 'dist/components', { recursive: true })
       // Copy dev UI (served at runtime by Vite)
       cpSync('src/server/ui', 'dist/server/ui', { recursive: true })
+      // Copy the parallel-build worker entry (plain JS, loaded by tinypool at runtime)
+      cpSync('src/render/parallel/worker.mjs', 'dist/render/parallel/worker.mjs')
     },
   },
 })


### PR DESCRIPTION
## Parallel build across worker threads

Large projects (hundreds–thousands of templates) build slowly because templates render sequentially through a single Vite SSR renderer. This adds an opt-in/auto parallel build that shards templates across worker threads.

### Config

New top-level `parallel` key:

```ts
parallel?: boolean | { workers?: number; threshold?: number }
```

- **omitted (default)** - auto: parallel when there are **more than 50 templates**, sequential below
- **`true`** - always parallel, `min(CPU − 1, 8)` workers
- **`false`** - always sequential
- **`{ workers, threshold }`** - `workers` thread count (default `min(CPU − 1, 8)`), `threshold` template count to trigger parallel (default `50`, `0` = always)

### How it works

- **Main thread** runs `beforeCreate` once, shards the template list, and runs `afterBuild` once with the full file list.
- **Each worker** reloads the config file (to recover function hooks - functions can't cross the thread boundary), then renders + transforms + writes its batch via the same `buildTemplate()` the sequential path uses, firing per-template events (`beforeRender`/`afterRender`/`afterTransform`) in-thread.
- No event handler closure ever crosses a thread boundary, so output is identical to a sequential build.
- Uses `tinypool`; the worker entry is a tiny jiti shim that loads the compiled `.js` in dist and the `.ts` source in dev/tests.

### Benchmarks 

Setup: 24-core machine, default `two-factor.vue` Maizzle 6 template.

The worker count matters more than the threshold, over-provisioning hurts:

| N=256 | 4w | **8w** | 12w | 16w | 23w |
|------|----|----|----|----|----|
| time | 10.2s | **9.3s** | 9.2s | 10.7s | 13.5s |

So the default caps at **8 workers**. With that cap the crossover is ~25 templates:

| templates | sequential | parallel (8w) | speedup |
|---|---|---|---|
| 64 | 6.4s | 4.2s | 1.5× |
| 128 | 12.3s | 6.4s | 1.9× |
| 1024 | 93s | 25s | **3.7×** |

### Behavior & limits

- Only applies to **file-based configs** (CLI / config path / default cwd config) — workers reload the config file; a programmatic inline config object can't provide that, so it builds sequentially.
- SFC-registered `afterBuild` handlers can't run in a worker (they'd need to fire once on the main thread with the aggregate file list) - they're counted and a warning is logged; use the config `afterBuild` hook instead.
- Small builds stay sequential (no worker startup overhead).

### Tests

`resolveParallel` gating (threshold, worker cap, explicit override, `false`, inline-object fallback) + two end-to-end parallel builds
verifying config events fire in workers and output matches sequential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel template building via a new `parallel` option with worker/threshold controls.
  * Builds now preserve template subdirectory structure under the output directory.
  * Per-template rendering supports source overrides and isolated per-template config handling.

* **Tests**
  * Expanded test coverage for parallel builds, per-template hooks, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->