### PR TITLE
refactor(render): resolve config from object only, no disk read

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -41,6 +41,34 @@ export async function resolveConfig(
   // Programmatic config (object) overrides file config, which overrides defaults
   const programmaticConfig = typeof config === 'object' && config !== null ? config : {}
 
+  return normalizeConfig(programmaticConfig, fileConfig, cwd)
+}
+
+/**
+ * Resolve config from a programmatic object only — never touches disk.
+ *
+ * `render()` uses this so a stray `maizzle.config.{ts,js}` in `cwd` can't
+ * silently alter output: the config you pass is the config you get, layered
+ * over defaults. Callers who want the project's file config load it
+ * explicitly via {@link resolveConfig} and pass the result in.
+ */
+export function resolveConfigObject(
+  config?: Partial<MaizzleConfig>,
+  cwd: string = process.cwd(),
+): MaizzleConfig {
+  const programmaticConfig = config && typeof config === 'object' ? config : {}
+  return normalizeConfig(programmaticConfig, {}, cwd)
+}
+
+/**
+ * Merge programmatic config over file config over defaults, then resolve
+ * filesystem paths (root, content, static, components) relative to cwd/root.
+ */
+function normalizeConfig(
+  programmaticConfig: Partial<MaizzleConfig>,
+  fileConfig: Partial<MaizzleConfig>,
+  cwd: string,
+): MaizzleConfig {
   const merged = merge(programmaticConfig, fileConfig, defaults) as MaizzleConfig
 
   // Check if root was explicitly provided before resolving

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,5 +1,5 @@
 import { resolve, extname } from 'node:path'
-import { resolveConfig } from '../config/index.ts'
+import { resolveConfigObject } from '../config/index.ts'
 import { runTransformers } from '../transformers/index.ts'
 import { createPlaintext } from '../plaintext.ts'
 import { stripForHtml, stripForPlaintext } from '../utils/output-markers.ts'
@@ -38,7 +38,7 @@ export async function render(
     )
   }
 
-  const resolvedConfig = await resolveConfig(config)
+  const resolvedConfig = resolveConfigObject(config)
 
   /**
    * Reuse a renderer started by the Vite plugin when one is active.

--- a/src/tests/render/config.test.ts
+++ b/src/tests/render/config.test.ts
@@ -35,6 +35,19 @@ describe('render', () => {
       expect(result.config.css?.preferUnitless).toBe(true)
     })
 
+    it('does not read maizzle.config from cwd', async () => {
+      writeFileSync(join(tempDir, 'maizzle.config.js'), 'export default { css: { safe: false } }')
+
+      const result = await render(`
+        <template>
+          <div>Test</div>
+        </template>
+      `)
+
+      // The on-disk config is ignored — defaults win, not the file's `safe: false`.
+      expect(result.config.css?.safe).toBe(true)
+    })
+
     it('uses template-level defineConfig()', async () => {
       const result = await render(`
         <script setup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* The render function now respects programmatically provided configuration exclusively, preventing unintended interference from on-disk configuration files during rendering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->