### PR TITLE
fix: merge custom td-class over base classes in CodeBlock

### DIFF
--- a/src/components/CodeBlock.vue
+++ b/src/components/CodeBlock.vue
@@ -21,10 +21,10 @@ export default {
       type: String as PropType<BundledTheme>,
       default: 'github-light'
     },
-    /** CSS class for the wrapping table cell. @default 'max-w-0 mso-padding-alt-4' */
+    /** Extra CSS classes for the wrapping table cell, merged over the base `max-w-0 mso-padding-alt-4`. */
     tdClass: {
       type: String,
-      default: 'max-w-0 mso-padding-alt-4'
+      default: ''
     }
   },
   inheritAttrs: false,
@@ -59,7 +59,7 @@ export default {
       .replace(/<\/code><\/pre>$/, '')
 
     const preClass = twMerge(codeBlockPreClass(bg), attrs.class as string)
-    const tdClass = twMerge(`bg-[${bg}]`, props.tdClass)
+    const tdClass = twMerge(`bg-[${bg}] max-w-0 mso-padding-alt-4`, props.tdClass)
     const styleAttr = attrs.style ? ` style="${attrs.style}"` : ''
 
     const html = buildCodeBlock(codeContent, bg, { preClass, tdClass, styleAttr })

--- a/src/tests/components/CodeBlock.test.ts
+++ b/src/tests/components/CodeBlock.test.ts
@@ -100,6 +100,20 @@ describe('CodeBlock', () => {
       expect(html).toMatch(/<td class="[^"]*\bbg-\[#fff\]/)
     })
 
+    it('keeps base td-class defaults when a custom td-class is passed', async () => {
+      const html = await render({ code: '<div>test</div>', 'td-class': 'custom-class' })
+
+      expect(html).toMatch(/<td class="[^"]*\bmax-w-0\b/)
+      expect(html).toMatch(/<td class="[^"]*\bmso-padding-alt-4\b/)
+    })
+
+    it('lets a custom td-class override a conflicting base utility via twMerge', async () => {
+      const html = await render({ code: '<div>test</div>', 'td-class': 'max-w-full' })
+
+      expect(html).toMatch(/<td class="[^"]*\bmax-w-full\b/)
+      expect(html).not.toMatch(/<td class="[^"]*\bmax-w-0\b/)
+    })
+
     it('sets the shiki theme background on the wrapping td as a class', async () => {
       const html = await render({ code: '<div>test</div>' })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated CSS class handling in the CodeBlock component to better separate base and custom styling, ensuring custom classes properly merge with and can override base utilities.

* **Tests**
  * Added test cases to verify CSS class merging behavior and confirm that custom styles can properly override conflicting base utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->