### PR TITLE
feat: strongly typed props when render vue component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "unplugin-vue-markdown": "^32.0.0",
         "uqr": "^0.1.3",
         "vite": "^8.0.16",
+        "vue-component-type-helpers": "^3.3.6",
         "vue-router": "^5.0.2"
       },
       "bin": {
@@ -8596,10 +8597,9 @@
       }
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.3.tgz",
-      "integrity": "sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==",
-      "dev": true,
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.6.tgz",
+      "integrity": "sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==",
       "license": "MIT"
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "unplugin-vue-markdown": "^32.0.0",
     "uqr": "^0.1.3",
     "vite": "^8.0.16",
+    "vue-component-type-helpers": "^3.3.6",
     "vue-router": "^5.0.2"
   },
   "peerDependencies": {

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -5,6 +5,7 @@ import { createPlaintext } from '../plaintext.ts'
 import { stripForHtml, stripForPlaintext } from '../utils/output-markers.ts'
 import defu from 'defu'
 import type { Component } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 import type { MaizzleConfig } from '../types/index.ts'
 import { createRenderer } from './createRenderer.ts'
 import { getActiveRenderer } from './active.ts'
@@ -20,12 +21,25 @@ export interface RenderResult {
 }
 
 /**
+ * Render a Vue component to a fully-transformed HTML string.
+ */
+export async function render<TComponent extends Component>(
+  component: TComponent,
+  config?: Partial<MaizzleConfig<ComponentProps<TComponent>>>,
+): Promise<RenderResult>;
+
+/**
  * Render a Vue SFC email template to a fully-transformed HTML string.
  * Accepts a file path or a raw SFC source string.
  */
 export async function render(
-  template: string | Component,
+  template: string,
   config?: Partial<MaizzleConfig>,
+): Promise<RenderResult>;
+
+export async function render<TComponent extends Component>(
+  template: string | TComponent,
+  config?: Partial<MaizzleConfig<ComponentProps<TComponent>>>,
 ): Promise<RenderResult> {
   if (template == null) {
     throw new Error(

--- a/src/tests/render/props.test.ts
+++ b/src/tests/render/props.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { defineComponent, h, type PropType } from 'vue'
 import { rmSync } from 'node:fs'
 import { render } from '../../render/index.ts'
 import { createTempProject } from './_helpers.ts'
@@ -30,6 +31,30 @@ describe('render props', () => {
     })
 
     expect(result.html).toContain('Hello Ava')
+  })
+
+  it('passes props to strongly typed component', async () => {
+    const component = defineComponent({
+      props: {
+        title: {
+          type: String as PropType<'Mr' | 'Ms' | 'Mx'>,
+          required: true,
+        },
+        name: {
+          type: String as PropType<string>,
+          required: true,
+        },
+      },
+      setup(props) {
+        return () => h('div', `Hello ${props.title} ${props.name}`)
+      }
+    })
+
+    const result = await render(component, {
+      props: { title: 'Mx', name: 'Ava' },
+    })
+
+    expect(result.html).toContain('Hello Mx Ava')
   })
 
   it('does not leak props into useConfig() or the returned config', async () => {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -493,7 +493,7 @@ export type ComponentSource =
     pathPrefix?: boolean
   }
 
-export interface MaizzleConfig {
+export interface MaizzleConfig<TProps = Record<string, any>> {
   /**
    * Root directory for the Maizzle email project.
    *
@@ -755,7 +755,7 @@ export interface MaizzleConfig {
    * @example
    * render('./welcome.vue', { props: { name: 'Ava', plan: 'Pro' } })
    */
-  props?: Record<string, any>
+  props?: TProps
 
   // Events
 


### PR DESCRIPTION
This pull request enhances type safety and flexibility when rendering Vue components by improving how props are typed and passed to components. The changes introduce generic typing for the `render` function and the `MaizzleConfig` interface, ensuring that props are strongly typed throughout the rendering process. Additionally, a new test verifies that props are correctly passed to strongly typed components.

**Type safety and API improvements:**

* The `render` function in `src/render/index.ts` now supports generic typing for Vue components, allowing props to be strongly typed using `ComponentProps<TComponent>`. This ensures better type inference and developer experience when rendering components. [[1]](diffhunk://#diff-eb8f63cd7e3c28d767a94232f636e75ef2ee2ba15aa214a17d6b3b69c08f982bR8) [[2]](diffhunk://#diff-eb8f63cd7e3c28d767a94232f636e75ef2ee2ba15aa214a17d6b3b69c08f982bR23-R42)
* The `MaizzleConfig` interface in `src/types/config.ts` is now generic, enabling the `props` field to be typed according to the component's expected props rather than always being `Record<string, any>`. [[1]](diffhunk://#diff-fea291e6a68bacafef88ed99be7ad4916267ab6585b42401f1f76ddcbb37706aL496-R496) [[2]](diffhunk://#diff-fea291e6a68bacafef88ed99be7ad4916267ab6585b42401f1f76ddcbb37706aL758-R758)

**Dependency updates:**

* Added the `vue-component-type-helpers` package to `package.json` to provide improved type utilities for Vue component props.

**Testing:**

* Added a new test in `src/tests/render/props.test.ts` to verify that props are correctly passed to a strongly typed Vue component, ensuring the new generic typing works as intended. [[1]](diffhunk://#diff-98dcfc8f90617ab6c557111cf1022cdd0e9c4737f81e9ad60d7caed1022a6f99R2) [[2]](diffhunk://#diff-98dcfc8f90617ab6c557111cf1022cdd0e9c4737f81e9ad60d7caed1022a6f99R36-R59)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved type support for rendering Vue components, including stronger typing for passed props.
  * Added support for generic config typing so component props can be validated more precisely.
* **Tests**
  * Added coverage for rendering a typed component with multiple prop types and verifying the output.
* **Dependencies**
  * Added a new runtime dependency to support the updated type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->