### PR TITLE
fix(render): strip SSR markers before teleport DOM round-trip

### DIFF
--- a/src/render/createRenderer.ts
+++ b/src/render/createRenderer.ts
@@ -511,6 +511,25 @@ export async function createRenderer(
         html = html.replace('</body>', `${bodyTags}\n</body>`)
       }
 
+      /**
+       * Strip Vue SSR fragment markers + teleport anchor comments. These
+       * are rendering hygiene, not transformer concerns — must run
+       * regardless of `useTransformers` state. Fragment markers contain
+       * `-->`, which would prematurely terminate MSO conditional
+       * comments downstream — including in the DOM round-trip below,
+       * whose parser would otherwise close `<!--[if mso]>` at a
+       * marker's `-->` and mangle the conditional on re-serialize.
+       */
+      const stripSsrMarkers = (str: string) => str
+        .replaceAll('<!--[-->', '')
+        .replaceAll('<!--]-->', '')
+        .replaceAll('<!--teleport start anchor-->', '')
+        .replaceAll('<!--teleport anchor-->', '')
+        .replaceAll('<!--teleport start-->', '')
+        .replaceAll('<!--teleport end-->', '')
+
+      html = stripSsrMarkers(html)
+
       // Inject SSR teleport content into their target elements
       const hasTeleports = ssrContext.teleports && Object.keys(ssrContext.teleports).length > 0
       const hasFonts = (renderContext.fonts?.length ?? 0) > 0
@@ -525,7 +544,7 @@ export async function createRenderer(
 
             const prepend = rawTarget.endsWith(':start')
             const target = prepend ? rawTarget.slice(0, -6) : rawTarget
-            const targetChildren = parseDom(content)
+            const targetChildren = parseDom(stripSsrMarkers(content))
 
             walk(dom, (node) => {
               const el = node as import('domhandler').Element
@@ -565,21 +584,6 @@ export async function createRenderer(
         const previewHtml = `<div style="display:none">${text}${filler}\u00A0</div>`
         html = html.replace(/<body([^>]*)>/, `<body$1>${previewHtml}`)
       }
-
-      /**
-       * Strip Vue SSR fragment markers + teleport anchor comments. These
-       * are rendering hygiene, not transformer concerns — must run
-       * regardless of `useTransformers` state. Fragment markers contain
-       * `-->`, which would prematurely terminate MSO conditional
-       * comments downstream.
-       */
-      html = html
-        .replaceAll('<!--[-->', '')
-        .replaceAll('<!--]-->', '')
-        .replaceAll('<!--teleport start anchor-->', '')
-        .replaceAll('<!--teleport anchor-->', '')
-        .replaceAll('<!--teleport start-->', '')
-        .replaceAll('<!--teleport end-->', '')
 
       return {
         html,

--- a/src/tests/render/createRenderer.test.ts
+++ b/src/tests/render/createRenderer.test.ts
@@ -49,6 +49,26 @@ describe('createRenderer', () => {
     expect(result.html).toContain('fonts.googleapis.com')
   })
 
+  it('keeps MSO conditionals intact when Preheader triggers the teleport DOM round-trip', async () => {
+    const config = await resolveConfig({ root: tempDir })
+    const result = await render(
+      `<template>
+        <Html>
+          <Head />
+          <Body>
+            <Preheader>Preview text</Preheader>
+            <Outlook><img src="https://example.com/image-a.gif"></Outlook>
+            <NotOutlook><img src="https://example.com/image-b.gif"></NotOutlook>
+          </Body>
+        </Html>
+      </template>`,
+      config,
+    )
+    expect(result.html).toContain('<!--[if mso]><img src="https://example.com/image-a.gif"><![endif]-->')
+    expect(result.html).toContain('<!--[if !mso]><!--><img src="https://example.com/image-b.gif"')
+    expect(result.html).not.toContain('---->')
+  })
+
   it('wraps a markdown code fence in a table with shiki highlighting', async () => {
     writeFileSync(join(tempDir, 'page.md'), '# Title\n\n```js\nconst x = 1\n```\n')
     const result = await render(join(tempDir, 'page.md'), { useTransformers: false })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered HTML processing so fragment markers and teleport anchors are stripped more reliably.
  * Preserved Outlook/MSO conditional comments during teleport-related HTML handling, preventing unwanted comment corruption in rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->