### PR TITLE
feat(server): allow exposing dev server on network via config

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -80,6 +80,7 @@ export async function serve(options: ServeOptions = {}) {
 
   let config = await resolveConfig(options.config)
   const port = options.port ?? config.server?.port ?? 3000
+  const host = options.host ?? config.server?.host
 
   // Create a renderer for SSR rendering email templates (with dts for dev)
   let renderer = await createRenderer({ dts: true, markdown: config.markdown, root: config.root, componentDirs: normalizeComponentSources(config.components?.source, process.cwd()), vite: config.vite })
@@ -132,7 +133,7 @@ export async function serve(options: ServeOptions = {}) {
     },
     server: {
       port,
-      host: options.host,
+      host,
       fs: {
         allow: [process.cwd(), config.root ?? process.cwd(), devUIDir, ...['vue', 'vue-router', 'reka-ui', '@vueuse/core', '@vueuse/shared', '@lucide/vue', 'class-variance-authority', 'clsx', 'tailwind-merge', 'culori'].map(pkg)],
       },

--- a/src/tests/serve.test.ts
+++ b/src/tests/serve.test.ts
@@ -131,6 +131,27 @@ describe('serve dev server', () => {
     }, { timeout: 15000, interval: 100 })
   }, 30000)
 
+  it('prefers options.host over config.server.host', async () => {
+    server = await serve({
+      host: '127.0.0.1',
+      config: { server: { host: '0.0.0.0' } },
+      port: 3157,
+      silent: true,
+    })
+
+    expect(server.config.server.host).toBe('127.0.0.1')
+  }, 30000)
+
+  it('falls back to config.server.host when options.host is undefined', async () => {
+    server = await serve({
+      config: { server: { host: '127.0.0.1' } },
+      port: 3157,
+      silent: true,
+    })
+
+    expect(server.config.server.host).toBe('127.0.0.1')
+  }, 30000)
+
   it('fires beforeRender/afterRender/afterTransform when rendering a template', async () => {
     writeFileSync(join(tempDir, 'maizzle.config.js'), `
       export default {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -604,6 +604,21 @@ export interface MaizzleConfig {
      */
     port?: number
     /**
+     * Expose the dev server on the network.
+     *
+     * Set to `true` to listen on all interfaces (prints a network URL +
+     * QR code), or pass a string to bind a specific address. The
+     * `--host` CLI flag takes precedence over this.
+     *
+     * @default false
+     *
+     * @example
+     * server: {
+     *   host: true,
+     * }
+     */
+    host?: boolean | string
+    /**
      * Additional file paths to watch for changes.
      *
      * @default []


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Maizzle!

**Please ask first before starting work on any significant new features.**

https://github.com/maizzle/framework/blob/master/.github/CONTRIBUTING.md

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the dev server host in project settings.
  * You can now bind the server to all interfaces or a specific address.
  * The command-line host option still takes priority when provided.
* **Bug Fixes**
  * Ensures the dev server uses the resolved host value when no command-line override is given.
* **Tests**
  * Added coverage for host precedence and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->