### PR TITLE
feat: allow passing Vite server options to the dev server

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -132,10 +132,14 @@ export async function serve(options: ServeOptions = {}) {
       ],
     },
     server: {
+      // Cherry-pick Vite's `server` options (e.g. watch.ignored) from the
+      // user's `vite` config; Maizzle's required keys below take precedence.
+      ...config.vite?.server,
       port,
       host,
       fs: {
-        allow: [process.cwd(), config.root ?? process.cwd(), devUIDir, ...['vue', 'vue-router', 'reka-ui', '@vueuse/core', '@vueuse/shared', '@lucide/vue', 'class-variance-authority', 'clsx', 'tailwind-merge', 'culori'].map(pkg)],
+        ...config.vite?.server?.fs,
+        allow: [process.cwd(), config.root ?? process.cwd(), devUIDir, ...['vue', 'vue-router', 'reka-ui', '@vueuse/core', '@vueuse/shared', '@lucide/vue', 'class-variance-authority', 'clsx', 'tailwind-merge', 'culori'].map(pkg), ...(config.vite?.server?.fs?.allow ?? [])],
       },
     },
     customLogger: customLogger(),

--- a/src/tests/serve.test.ts
+++ b/src/tests/serve.test.ts
@@ -152,6 +152,28 @@ describe('serve dev server', () => {
     expect(server.config.server.host).toBe('127.0.0.1')
   }, 30000)
 
+  it('passes config.vite.server options (watch.ignored) to the dev server', async () => {
+    server = await serve({
+      config: { vite: { server: { watch: { ignored: ['**/some-share/**'] } } } },
+      port: 3157,
+      silent: true,
+    })
+
+    expect(server.config.server.watch?.ignored).toContain('**/some-share/**')
+  }, 30000)
+
+  it('keeps Maizzle fs.allow when config.vite.server.fs.allow is set', async () => {
+    server = await serve({
+      config: { vite: { server: { fs: { allow: ['/custom/allowed'] } } } },
+      port: 3157,
+      silent: true,
+    })
+
+    // User path merged in, Maizzle's cwd still present (not replaced).
+    expect(server.config.server.fs.allow).toContain('/custom/allowed')
+    expect(server.config.server.fs.allow).toContain(process.cwd())
+  }, 30000)
+
   it('fires beforeRender/afterRender/afterTransform when rendering a template', async () => {
     writeFileSync(join(tempDir, 'maizzle.config.js'), `
       export default {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -737,9 +737,17 @@ export interface MaizzleConfig {
    * `configFile: false`), so pass anything it needs here. These options are
    * merged underneath Maizzle's required settings, which take precedence.
    *
+   * The `server` block is also applied to the dev server — use it to pass
+   * Vite server options such as `watch.ignored` (e.g. to stop the file
+   * watcher from crashing on network shares). Maizzle's `port`, `host`
+   * and `fs.allow` still take precedence.
+   *
    * @example
    * vite: {
    *   plugins: [myPlugin()],
+   *   server: {
+   *     watch: { ignored: ['**\/some-network-share/**'] },
+   *   },
    * }
    */
   vite?: InlineConfig


### PR DESCRIPTION
Closes #1793.

The dev server is a Vite server, but its `server` block only exposed `port`, `host` and `fs`. There was no way to pass Vite server options like `watch.ignored`, so file watching would crash on network shares (`UNKNOWN: unknown error, watch`) with no workaround.

This cherry-picks `config.vite.server` into the dev server's Vite `server` block. Maizzle's `port`, `host` and `fs.allow` still take precedence; a user-supplied `fs.allow` is merged in rather than replacing Maizzle's required paths.

```ts
vite: {
  server: {
    watch: { ignored: ['**/some-network-share/**'] },
  },
}
```

Adds tests for the `watch.ignored` passthrough and the `fs.allow` merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing development server settings, including file-watching options.
  * Custom filesystem allow-list paths are now preserved alongside required project paths.

* **Documentation**
  * Clarified development server configuration options, examples, and precedence for port, host, and filesystem settings.

* **Tests**
  * Added coverage for custom watch settings and filesystem path merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->