### PR TITLE
feat(prepare): install Maizzle skill into .claude/skills on prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "skills"
   ],
   "scripts": {
     "build": "tsdown",

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -1,4 +1,6 @@
-import { relative, resolve } from 'node:path'
+import { cpSync, existsSync, rmSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import ora from 'ora'
 import { resolveConfig } from './config/index.ts'
 import { createRenderer } from './render/createRenderer.ts'
@@ -46,4 +48,18 @@ export async function prepare(options: PrepareOptions = {}): Promise<void> {
     symbol: '✅',
     text: `Types generated in ${displayPath}`,
   })
+
+  // Copy the bundled Maizzle skill into the project's `.claude/skills/` so
+  // Claude Code auto-discovers it (it never scans `node_modules/`) and it stays
+  // in sync with the installed framework version on every install/upgrade.
+  const skillSrc = resolve(dirname(fileURLToPath(import.meta.url)), '../skills/maizzle')
+  if (existsSync(skillSrc)) {
+    const skillDest = resolve(process.cwd(), '.claude/skills/maizzle')
+    rmSync(skillDest, { recursive: true, force: true })
+    cpSync(skillSrc, skillDest, { recursive: true })
+    ora().stopAndPersist({
+      symbol: '✅',
+      text: `Maizzle skill installed in ${relative(process.cwd(), skillDest) || skillDest}`,
+    })
+  }
 }


### PR DESCRIPTION
## What

Makes the bundled Maizzle skill available to Claude Code automatically after install.

- Add `skills` to the package `files` array so `skills/maizzle` ships in `node_modules/@maizzle/framework/`.
- In `prepare` (the starter's `postinstall` step), copy `skills/maizzle` → `<project>/.claude/skills/maizzle`.

## Why

Claude Code auto-discovers project-level `.claude/skills/` (and `~/.claude/skills/`) but **never scans `node_modules/`**. So shipping the skill in the package alone is necessary but not discoverable. Copying it into the project's `.claude/skills/` during `prepare` makes it:

- **Auto-discovered** — it lives where Claude Code scans.
- **Version-synced** — refreshed on every `npm i`/upgrade via `postinstall: maizzle prepare`, instead of frozen at scaffold time in the starter.

`rm`-then-`cp` prunes files removed upstream; `cpSync` creates the `.claude/skills/` parents. Source is resolved from the package via `import.meta.url` and guarded with `existsSync`, so it's a no-op when the skill isn't present.

## Test

- `npm pack --dry-run` confirms `skills/maizzle/**` is in the tarball.
- Verified the copy end-to-end against a temp project cwd (creates parents, prunes stale files, idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically installs the bundled Maizzle skill into the project’s Claude skills directory during preparation.
  * Replaces any existing copy to ensure the latest skill version is available.
  * Reports successful skill installation when available.

* **Chores**
  * The published package now includes the bundled skills directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->