### PR TITLE
feat(dev-server): keep sidebar folder label on one line

### DIFF
--- a/src/server/ui/App.vue
+++ b/src/server/ui/App.vue
@@ -300,6 +300,9 @@ const vFade = {
     ;(el as any)._fade = update
     el.addEventListener('scroll', update, { passive: true })
     window.addEventListener('resize', update)
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    ;(el as any)._fadeObserver = observer
     requestAnimationFrame(update)
   },
   updated(el: HTMLElement) {
@@ -308,6 +311,7 @@ const vFade = {
   unmounted(el: HTMLElement) {
     el.removeEventListener('scroll', (el as any)._fade)
     window.removeEventListener('resize', (el as any)._fade)
+    ;(el as any)._fadeObserver?.disconnect()
   },
 }
 

--- a/src/server/ui/App.vue
+++ b/src/server/ui/App.vue
@@ -290,6 +290,27 @@ function toggleDarkMode() {
   darkMode.value = !darkMode.value
 }
 
+const vFade = {
+  mounted(el: HTMLElement) {
+    const update = () => {
+      const max = el.scrollWidth - el.clientWidth
+      el.style.setProperty('--fade-l', el.scrollLeft > 1 ? 'transparent' : '#000')
+      el.style.setProperty('--fade-r', el.scrollLeft < max - 1 ? 'transparent' : '#000')
+    }
+    ;(el as any)._fade = update
+    el.addEventListener('scroll', update, { passive: true })
+    window.addEventListener('resize', update)
+    requestAnimationFrame(update)
+  },
+  updated(el: HTMLElement) {
+    requestAnimationFrame((el as any)._fade)
+  },
+  unmounted(el: HTMLElement) {
+    el.removeEventListener('scroll', (el as any)._fade)
+    window.removeEventListener('resize', (el as any)._fade)
+  },
+}
+
 onMounted(() => {
   document.addEventListener('keydown', onKeydown)
   window.addEventListener('blur', onWindowBlur)
@@ -329,7 +350,9 @@ onUnmounted(() => {
           </SidebarGroup>
 
           <SidebarGroup v-for="(items, dir) in grouped" :key="dir" v-else>
-            <SidebarGroupLabel>{{ dir }}</SidebarGroupLabel>
+            <SidebarGroupLabel>
+              <span v-fade class="min-w-0 overflow-x-auto whitespace-nowrap scrollbar-hide fade-scroll">{{ dir }}</span>
+            </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 <SidebarMenuItem v-for="t in items" :key="t.path">

--- a/src/server/ui/main.css
+++ b/src/server/ui/main.css
@@ -152,3 +152,18 @@
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22h6a2 2 0 0 0 2-2V8a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 14 2H6a2 2 0 0 0-2 2v6'/%3E%3Cpath d='M14 2v5a1 1 0 0 0 1 1h5'/%3E%3Cpath d='M3 22V14l4 4 4-4v8'/%3E%3C/svg%3E");
           mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='1' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22h6a2 2 0 0 0 2-2V8a2.4 2.4 0 0 0-.706-1.706l-3.588-3.588A2.4 2.4 0 0 0 14 2H6a2 2 0 0 0-2 2v6'/%3E%3Cpath d='M14 2v5a1 1 0 0 0 1 1h5'/%3E%3Cpath d='M3 22V14l4 4 4-4v8'/%3E%3C/svg%3E");
 }
+
+@utility scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@utility fade-scroll {
+  --fade-l: #000;
+  --fade-r: #000;
+  -webkit-mask-image: linear-gradient(to right, var(--fade-l) 0, #000 1.5rem, #000 calc(100% - 1.5rem), var(--fade-r) 100%);
+          mask-image: linear-gradient(to right, var(--fade-l) 0, #000 1.5rem, #000 calc(100% - 1.5rem), var(--fade-r) 100%);
+}


### PR DESCRIPTION
## What

Long folder/group paths in the dev server sidebar wrapped to multiple lines. Now they stay on a single line with native horizontal scroll (scrollbar hidden), and edge fades signal when there's more to scroll.

## Changes

- `src/server/ui/App.vue` — the group label text renders in a scrollable `<span>` with a `v-fade` directive.
- `src/server/ui/main.css` — new `scrollbar-hide` and `fade-scroll` utilities.

## Behavior

- Label stays on one line, scrolls horizontally, no visible scrollbar.
- **Right** edge fades only when there's more content to the right.
- **Left** edge fades only once scrolled away from the start.
- No fade at all when the label fits (short paths are unaffected).
- Recomputes on scroll, window resize, and label list changes.

## Before

<img width="433" height="192" alt="image" src="https://github.com/user-attachments/assets/04b63869-c187-4f1b-b7c9-749e1932a219" />

## After

<img width="417" height="200" alt="image" src="https://github.com/user-attachments/assets/2b82f80f-73ab-422b-b274-85ece66a73d4" />

<img width="424" height="185" alt="image" src="https://github.com/user-attachments/assets/91f56795-0efe-4b3e-9c69-c2cb7ad10c2d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added horizontal scrolling for long sidebar directory labels.
  * Added subtle edge fades to indicate additional off-screen content.
  * Hidden scrollbars provide a cleaner appearance while preserving scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->