### PR TITLE
fix: use the shadcn scrollbar for the dev UI sidebar

### DIFF
--- a/src/server/ui/App.vue
+++ b/src/server/ui/App.vue
@@ -344,7 +344,7 @@ onUnmounted(() => {
       </SidebarHeader>
 
       <SidebarContent>
-        <ScrollArea class="flex-1">
+        <ScrollArea class="flex-1 min-h-0">
           <SidebarGroup v-if="loading">
             <p class="px-2 py-4 text-xs text-gray-500 dark:text-gray-400">Loading emails...</p>
           </SidebarGroup>


### PR DESCRIPTION
## Problem

The dev UI sidebar (template list) showed the **native** browser scrollbar, unlike the preview pane which uses the shadcn `ScrollArea` bar.

## Cause

The list is wrapped in `<ScrollArea class="flex-1">` inside `<SidebarContent>`, but the ScrollArea has no `min-h-0`. A flex child defaults to `min-height: auto`, so the ScrollArea grew to its full content height instead of being bounded by the flex container. Its internal viewport therefore never needed to scroll — the custom scrollbar never engaged — and the overflow fell through to `SidebarContent` (`overflow-auto`), surfacing the native bar.

## Fix

Add `min-h-0` so the ScrollArea is height-bounded, its viewport scrolls internally, and the shadcn scrollbar is used — matching the preview pane.

```diff
-        <ScrollArea class="flex-1">
+        <ScrollArea class="flex-1 min-h-0">
```

One-line change, isolated to the dev UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar layout behavior so its scrollable area shrinks correctly and remains usable across varying content sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->