### PR TITLE
fix: prevent infinite loop in base URL with a relative base

### DIFF
--- a/src/tests/transformers/base.test.ts
+++ b/src/tests/transformers/base.test.ts
@@ -243,6 +243,22 @@ describe('base URL', () => {
       const result = run(html, { url: { base: 'https://cdn.example.com/' } })
       expect(result).toBe(html)
     })
+
+    it('prepends a relative base to url() exactly once (no infinite re-prepend)', () => {
+      // A relative base never makes the URL absolute; the PostCSS declaration
+      // must not be re-visited, or it re-prepends forever and hangs.
+      const html = '<style>.bg { background-image: url(bg.jpg) }</style>'
+      const result = run(html, { url: { base: '/images/' } })
+      expect(result).toContain('url(/images/bg.jpg)')
+      expect(result).not.toContain('/images//images/')
+    })
+
+    it('prepends a relative base in an inline style exactly once', () => {
+      const html = '<div style="background-image: url(bg.jpg)"></div>'
+      const result = run(html, { url: { base: '/images/' } })
+      expect(result).toContain('url(/images/bg.jpg)')
+      expect(result).not.toContain('/images//images/')
+    })
   })
 
   describe('inlineCss option', () => {

--- a/src/transformers/base.ts
+++ b/src/transformers/base.ts
@@ -54,30 +54,42 @@ const defaultTagConfig: Record<string, Record<string, string | boolean>> = Objec
 )
 
 const postcssBaseUrl: postcss.PluginCreator<{ url: string }> = (opts) => {
+  const rewriteDecl = (decl: postcss.Declaration) => {
+    if (!decl.value.includes('url(')) return
+
+    const parsed = valueParser(decl.value)
+    let changed = false
+
+    parsed.walk(node => {
+      if (node.type !== 'function' || node.value !== 'url') return
+
+      const urlNode = node.nodes[0]
+      if (!urlNode) return
+
+      if (isAbsoluteUrl(urlNode.value)) return
+
+      urlNode.value = opts!.url + urlNode.value
+      changed = true
+    })
+
+    if (changed) {
+      decl.value = parsed.toString()
+    }
+  }
+
   return {
     postcssPlugin: 'postcss-base-url',
-    Declaration(decl) {
-      if (!decl.value.includes('url(')) return
-
-      const parsed = valueParser(decl.value)
-      let changed = false
-
-      parsed.walk(node => {
-        if (node.type !== 'function' || node.value !== 'url') return
-
-        const urlNode = node.nodes[0]
-        if (!urlNode) return
-
-        if (isAbsoluteUrl(urlNode.value)) return
-
-        urlNode.value = opts!.url + urlNode.value
-        changed = true
-      })
-
-      if (changed) {
-        decl.value = parsed.toString()
-      }
-    }
+    /**
+     * Walk declarations once, in `OnceExit`, rather than via the visitor
+     * `Declaration` hook. The visitor re-runs on nodes it mutates, and a
+     * relative base (e.g. `/images/`) never makes the URL absolute — so the
+     * guard `isAbsoluteUrl` stays false and it re-prepends the base forever
+     * (`/images//images/…`), hanging the build. A single manual pass rewrites
+     * each declaration exactly once.
+     */
+    OnceExit(root) {
+      root.walkDecls(rewriteDecl)
+    },
   }
 }
 postcssBaseUrl.postcss = true


### PR DESCRIPTION
## Problem

Setting a **relative** `url.base` (e.g. `/images/`) hangs the build / dev server — the process spins at 100% CPU and memory climbs unbounded — whenever the document contains a `url()` in a `<style>` block or inline `style` attribute.

Minimal repro:
```js
import { base } from '@maizzle/framework'
base('<style>a{background-image:url(x.jpg)}</style>', '/images/') // hangs forever
base('<style>a{background-image:url(x.jpg)}</style>', 'https://cdn/') // fine
```

## Cause

`postcssBaseUrl` rewrites `url()` from a PostCSS `Declaration` visitor. PostCSS 8 **re-visits a declaration whose value a visitor mutates** (so other plugins can react). The plugin prepends the base only when `isAbsoluteUrl(value)` is false — but with a relative base the result (`/images/x.jpg`) is *still* not absolute, so on the re-visit the guard is false again and it prepends once more: `/images//images/x.jpg` → `/images//images//images/…`, forever.

Absolute bases become absolute after the first prepend, so the guard trips and the loop terminates — which is why it only surfaced with relative bases (common in dev, where the CDN isn't wanted).

## Fix

Rewrite declarations in a single `OnceExit` pass via `root.walkDecls`, which visits each declaration exactly once and is not subject to the visitor re-run semantics. Attribute/VML/MSO handling is unchanged.

## Tests

Added regression tests for a relative base with `url()` in a `<style>` tag and in an inline `style` — each asserts the base is prepended exactly once (`url(/images/bg.jpg)`, never `/images//images/`). Full `base.test.ts` suite green (79 tests), lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS URL rewriting to prevent base paths from being added more than once.
  * Improved handling of relative base URLs in both `<style>` blocks and inline styles.
  * Ensured image and other asset paths retain the correct URL structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->