### PR TITLE
fix: relative base URL double-prefix and skipped inline styles

### DIFF
--- a/src/tests/transformers/base.test.ts
+++ b/src/tests/transformers/base.test.ts
@@ -308,6 +308,15 @@ describe('base URL', () => {
       expect(result).toContain('src="https://cdn.example.com/b.js"')
     })
 
+    it('still rewrites inline style url() when tags are restricted', () => {
+      // The tags filter restricts source attributes (src/href/…), not the
+      // CSS url() rewriting — that is governed by `inlineCss`. A background
+      // image on a non-listed tag (<td>) must still be prefixed.
+      const html = '<td style="background-image: url(bg.jpg)"></td>'
+      const result = run(html, { url: { base: { url: 'https://cdn.example.com/', tags: ['img'] } } })
+      expect(result).toContain('url(https://cdn.example.com/bg.jpg)')
+    })
+
     it('accepts object-format tags with per-attribute config', () => {
       const html = '<img src="a.jpg" srcset="b.jpg 1x"><a href="page.html">Link</a>'
       const result = run(html, {
@@ -445,6 +454,23 @@ describe('base URL', () => {
       const html = '<v:fill src="https://other.com/bg.png"/>'
       const result = run(html, { url: { base: 'https://cdn.example.com/' } })
       expect(result).toContain('src="https://other.com/bg.png"')
+    })
+
+    it('prefixes v:fill in MSO comments once with a relative base', () => {
+      // rewriteVMLs and rewriteMsoComments both target src inside MSO
+      // comments; a relative base never trips isAbsoluteUrl, so without the
+      // startsWith guard the src is prefixed twice (/images//images/…).
+      const html = '<!--[if gte vml 1]><v:fill src="bg.png"/><![endif]-->'
+      const result = run(html, { url: { base: '/images/' } })
+      expect(result).toContain('src="/images/bg.png"')
+      expect(result).not.toContain('/images//images/')
+    })
+
+    it('prefixes v:image in MSO comments once with a relative base', () => {
+      const html = '<!--[if gte vml 1]><v:image src="hero.png"/><![endif]-->'
+      const result = run(html, { url: { base: '/images/' } })
+      expect(result).toContain('src="/images/hero.png"')
+      expect(result).not.toContain('/images//images/')
     })
   })
 

--- a/src/tests/transformers/base.test.ts
+++ b/src/tests/transformers/base.test.ts
@@ -472,6 +472,16 @@ describe('base URL', () => {
       expect(result).toContain('src="/images/hero.png"')
       expect(result).not.toContain('/images//images/')
     })
+
+    it('rewrites v:image/v:fill under /images2 with a no-trailing-slash base /images', () => {
+      // The skip guard must match at a path boundary, not a bare string
+      // prefix — base `/images` must not swallow a `/images2/…` source.
+      const image = run('<v:image src="/images2/hero.png"/>', { url: { base: '/images' } })
+      expect(image).toContain('src="/images/images2/hero.png"')
+
+      const fill = run('<v:fill src="/images2/bg.png"/>', { url: { base: '/images' } })
+      expect(fill).toContain('src="/images/images2/bg.png"')
+    })
   })
 
   describe('MSO comments', () => {

--- a/src/transformers/base.ts
+++ b/src/transformers/base.ts
@@ -200,25 +200,31 @@ export function baseDom(dom: ChildNode[], options: string | BaseUrlOptions | und
       return
     }
 
-    // Process tag-specific attributes (respects tags filter)
+    // Rewrite url() in an inline style attribute. Controlled by `inlineCss`
+    // only — NOT the `tags` filter, which restricts source-attribute rewriting
+    // (src/href/…). A `tags: ['img']` config must still rewrite the background
+    // image on a `<td style="…url(bg.jpg)…">`, matching how <style> tags work.
+    if (inlineCss && el.attribs.style?.includes('url(')) {
+      const newStyle = processInlineStyle(el.attribs.style, baseUrl)
+      if (newStyle !== el.attribs.style) {
+        el.attribs.style = newStyle
+      }
+    }
+
+    // Process tag-specific source attributes (respects tags filter)
     const tagConfig = getTagConfig(el.name, resolved)
 
     if (tagConfig || resolved.tags === undefined) {
       for (const [attr, value] of Object.entries(el.attribs)) {
-        if (!value) continue
+        if (!value || attr === 'style') continue
 
         const attrConfig = tagConfig?.[attr]
-        if (!attrConfig && attr !== 'style') continue
+        if (!attrConfig) continue
 
         if (attr === 'srcset' && (attrConfig === true || typeof attrConfig === 'string')) {
           const newSrcset = processSrcset(value, typeof attrConfig === 'string' ? attrConfig : baseUrl)
           if (newSrcset !== value) {
             el.attribs.srcset = newSrcset
-          }
-        } else if (attr === 'style' && inlineCss && value.includes('url(')) {
-          const newStyle = processInlineStyle(value, baseUrl)
-          if (newStyle !== value) {
-            el.attribs.style = newStyle
           }
         } else if (attrConfig === true && !isAbsoluteUrl(value)) {
           el.attribs[attr] = baseUrl + value
@@ -253,12 +259,12 @@ export function baseDom(dom: ChildNode[], options: string | BaseUrlOptions | und
 
 function rewriteVMLs(html: string, url: string): string {
   html = html.replace(/<v:image[^>]+src="?([^"\s]+)"/gi, (match, src) => {
-    if (isAbsoluteUrl(src)) return match
+    if (isAbsoluteUrl(src) || src.startsWith(url)) return match
     return match.replace(src, url + src)
   })
 
   html = html.replace(/<v:fill[^>]+src="?([^"\s]+)"/gi, (match, src) => {
-    if (isAbsoluteUrl(src)) return match
+    if (isAbsoluteUrl(src) || src.startsWith(url)) return match
     return match.replace(src, url + src)
   })
 
@@ -272,7 +278,14 @@ function rewriteMsoComments(html: string, url: string): string {
     for (const attr of sourceAttributes) {
       const attrRegex = new RegExp(`\\b${attr}="([^"]+)"`, 'gi')
       result = result.replace(attrRegex, (match, value) => {
-        if (isAbsoluteUrl(value)) return match
+        /**
+         * `startsWith(url)` guards against a relative base being prepended
+         * twice: `rewriteVMLs` runs first and prefixes `v:image`/`v:fill`
+         * `src`; this generic pass would otherwise re-prefix the same
+         * attribute (`/images//images/…`) since a relative base never trips
+         * `isAbsoluteUrl`. Absolute bases self-guard via `isAbsoluteUrl`.
+         */
+        if (isAbsoluteUrl(value) || value.startsWith(url)) return match
 
         if (attr === 'srcset') {
           return `srcset="${processSrcset(value, url)}"`

--- a/src/transformers/base.ts
+++ b/src/transformers/base.ts
@@ -257,14 +257,24 @@ export function baseDom(dom: ChildNode[], options: string | BaseUrlOptions | und
   return dom
 }
 
+/**
+ * True when `value` already sits under `url` — used to skip re-prefixing an
+ * already-based URL (e.g. after `rewriteVMLs` runs before `rewriteMsoComments`)
+ * without matching a mere string prefix: base `/images` must NOT swallow
+ * `/images2/…`, so we require a path boundary (exact match or a following `/`).
+ */
+function isUnderBase(value: string, url: string): boolean {
+  return value === url || value.startsWith(url.endsWith('/') ? url : `${url}/`)
+}
+
 function rewriteVMLs(html: string, url: string): string {
   html = html.replace(/<v:image[^>]+src="?([^"\s]+)"/gi, (match, src) => {
-    if (isAbsoluteUrl(src) || src.startsWith(url)) return match
+    if (isAbsoluteUrl(src) || isUnderBase(src, url)) return match
     return match.replace(src, url + src)
   })
 
   html = html.replace(/<v:fill[^>]+src="?([^"\s]+)"/gi, (match, src) => {
-    if (isAbsoluteUrl(src) || src.startsWith(url)) return match
+    if (isAbsoluteUrl(src) || isUnderBase(src, url)) return match
     return match.replace(src, url + src)
   })
 
@@ -279,13 +289,13 @@ function rewriteMsoComments(html: string, url: string): string {
       const attrRegex = new RegExp(`\\b${attr}="([^"]+)"`, 'gi')
       result = result.replace(attrRegex, (match, value) => {
         /**
-         * `startsWith(url)` guards against a relative base being prepended
-         * twice: `rewriteVMLs` runs first and prefixes `v:image`/`v:fill`
-         * `src`; this generic pass would otherwise re-prefix the same
-         * attribute (`/images//images/…`) since a relative base never trips
+         * `isUnderBase` guards against a relative base being prepended twice:
+         * `rewriteVMLs` runs first and prefixes `v:image`/`v:fill` `src`; this
+         * generic pass would otherwise re-prefix the same attribute
+         * (`/images//images/…`) since a relative base never trips
          * `isAbsoluteUrl`. Absolute bases self-guard via `isAbsoluteUrl`.
          */
-        if (isAbsoluteUrl(value) || value.startsWith(url)) return match
+        if (isAbsoluteUrl(value) || isUnderBase(value, url)) return match
 
         if (attr === 'srcset') {
           return `srcset="${processSrcset(value, url)}"`


### PR DESCRIPTION
Two more relative-base bugs in the base URL transformer, both surfaced with a **relative** `url.base` (e.g. `/images/`) and masked by absolute bases — an absolute base becomes absolute after one prepend, so `isAbsoluteUrl` self-guards. Follow-up to #1825 (the infinite-loop fix), same file.

## 1. VML `src` double-prefixed inside MSO comments

A `v:image`/`v:fill` `src` inside an MSO conditional comment is rewritten by **both** `rewriteVMLs` and `rewriteMsoComments`' generic `src=` pass. With a relative base neither pass sees the value as absolute, so it's prepended twice:

```
<v:fill src="hero.jpg"> → src="/images//images/hero.jpg"
```

Fix: guard the MSO/VML passes with `startsWith(url)` so an already-prefixed `src` (from the first pass) is left alone. Absolute bases keep self-guarding via `isAbsoluteUrl`.

## 2. Inline `style` `url()` skipped when `tags` is restricted

The inline-`style` `url()` rewrite sat *inside* the `tags`-filter gate, so `tags: ['img']` skipped a background image on any non-listed tag:

```
<td style="background-image: url(bg.jpg)"> → unchanged
```

The `tags` filter is meant to restrict *source attributes* (`src`/`href`/…), not CSS `url()` rewriting — which is governed by `inlineCss` (mirroring how `<style>` tags are handled). Fix: move the inline-style rewrite out of the tag gate.

## Tests

Added regression tests (relative base): `v:fill`/`v:image` in MSO comments prefixed exactly once (no `/images//images/`), and inline `style` `url()` still rewritten under `tags: ['img']`. Full suite green (1772), lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inline CSS URLs so they are consistently rewritten, including on restricted tags.
  * Prevented duplicate base URLs in VML and MSO comment image sources.
  * Preserved tag filtering for supported source attributes.
  * Improved handling of similar paths, ensuring only the intended base URL is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->