### PR TITLE
fix(button): move icon vertical-align from inline style to a class default

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -203,7 +203,7 @@ const MsoIconGap = () => createStaticVNode(
         <MsoSpacerLeft v-if="outlookFallback" />
         <template v-if="icon && iconPosition === 'left'">
           <span :style="textSpanStyle">
-            <img :src="icon" :width="parsedIconWidth" :alt="iconAlt" style="vertical-align: baseline; max-width: 100%;" :class="iconClass">
+            <img :src="icon" :width="parsedIconWidth" :alt="iconAlt" :class="twMerge('max-w-full align-baseline', iconClass)">
           </span>
           <MsoIconGap v-if="outlookFallback" />
         </template>
@@ -211,7 +211,7 @@ const MsoIconGap = () => createStaticVNode(
         <template v-if="icon && iconPosition === 'right'">
           <MsoIconGap v-if="outlookFallback" />
           <span :style="textSpanStyle">
-            <img :src="icon" :width="parsedIconWidth" :alt="iconAlt" style="vertical-align: baseline; max-width: 100%;" :class="iconClass">
+            <img :src="icon" :width="parsedIconWidth" :alt="iconAlt" :class="twMerge('max-w-full align-baseline', iconClass)">
           </span>
         </template>
         <MsoSpacerRight v-if="outlookFallback" />


### PR DESCRIPTION
### Problem

The icon `<img>` in `<Button>` hardcodes an inline style alongside `:class`:

```html
<img … style="vertical-align: baseline; max-width: 100%;" :class="iconClass">
```

Since Tailwind utilities are imported `!important` in email (`@import "tailwindcss/utilities" important`), a passed `iconClass` like `align-text-top` **already** wins over the inline `vertical-align: baseline` in a normal inlined build. So the hardcoded inline style is effectively dead — the real cascade resolves to the class.

The trouble shows up in a **class-first workflow** that de-inlines residual `style=""` back into utility classes: that dead inline `vertical-align: baseline` gets converted into an `align-baseline` utility and stacked next to the authored `align-text-top`. Two conflicting `!important` vertical-align utilities land on one element, and the wrong one can win.

### Fix

Move the icon defaults from an inline style to a `twMerge`'d class, so `iconClass` overrides them cleanly and no inline `vertical-align` is emitted:

```diff
-<img … style="vertical-align: baseline; max-width: 100%;" :class="iconClass">
+<img … :class="twMerge('max-w-full align-baseline', iconClass)">
```

`twMerge` already collapses vertical-align conflicts, so:

- default (`iconClass=''`) → `max-w-full align-baseline` (unchanged behavior)
- `iconClass="align-text-top"` → `max-w-full align-text-top`

Output is identical for the default and for inlined builds; the class-first path now yields a single, correct vertical-align. Applied to both icon positions (left/right).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button icon sizing and baseline alignment.
  * Applied the styling consistently to icons positioned on either side of a button while preserving custom icon styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->