### PR TITLE
feat: flatten Tailwind gradients into email-safe declarations

### DIFF
--- a/src/plugins/postcss/flattenGradients.ts
+++ b/src/plugins/postcss/flattenGradients.ts
@@ -21,7 +21,8 @@
  * every other Tailwind color. The dead utility rules are then removed.
  */
 
-import type { Plugin, Root, Rule } from 'postcss'
+import { Rule } from 'postcss'
+import type { Plugin, Root } from 'postcss'
 
 const PLUGIN_NAME = 'postcss-flatten-gradients'
 
@@ -44,6 +45,8 @@ interface UtilityInfo {
   fromPosition?: string
   viaPosition?: string
   toPosition?: string
+  /** The source rule, used to anchor the generated rule in the cascade. */
+  rule?: Rule
 }
 
 const GRADIENT_UTILITY_RE = /^(from|via|to)-|^bg-(linear|radial|conic)\b/
@@ -117,6 +120,7 @@ export default (combos: GradientCombo[] = []): Plugin => {
           }
         })
 
+        info.rule = rule
         utilities.set(cls, info)
       })
 
@@ -162,9 +166,21 @@ export default (combos: GradientCombo[] = []): Plugin => {
 
         const args = direction ? `${direction}, ${stops.join(', ')}` : stops.join(', ')
 
-        root.append({ selector: `.${combo.className}` } as Rule)
-        const created = root.last as Rule
-        created.append({ prop: 'background-image', value: `${fn}-gradient(${args})` })
+        const generated = new Rule({ selector: `.${combo.className}` })
+        generated.append({ prop: 'background-image', value: `${fn}-gradient(${args})` })
+
+        /**
+         * Insert at the position of the source utility rule (still present
+         * — removal happens below) so the gradient keeps that rule's place
+         * in the cascade. Appending to the root would move it past any
+         * later author CSS that should override it.
+         */
+        const anchor = fnInfo?.rule
+        if (anchor?.parent) {
+          anchor.before(generated)
+        } else {
+          root.append(generated)
+        }
       }
 
       // Remove the now-dead gradient utility rules.

--- a/src/plugins/postcss/flattenGradients.ts
+++ b/src/plugins/postcss/flattenGradients.ts
@@ -1,0 +1,181 @@
+/**
+ * postcss-flatten-gradients
+ *
+ * Tailwind v4 renders gradients as CSS-variable machinery split across
+ * separate utility rules (`bg-linear-*`, `from-*`, `via-*`, `to-*`),
+ * combining only on the element that carries every class. Email clients
+ * don't support `var()` and Maizzle inlines styles, so the variables
+ * never resolve and the gradient renders nothing.
+ *
+ * Given the per-element gradient combos (computed from the DOM by the
+ * tailwindcss transformer), this plugin reads the `--tw-gradient-*`
+ * values off the utility rules and emits a single flat rule per combo:
+ *
+ *   .bg-linear-gradient-to-bl-from-indigo-50-to-indigo-600 {
+ *     background-image: linear-gradient(to bottom left,
+ *       var(--color-indigo-50), var(--color-indigo-600));
+ *   }
+ *
+ * Colors stay as `var(--color-*)` (or literals) so the downstream
+ * resolveProps + lightningcss steps convert them to hex, exactly like
+ * every other Tailwind color. The dead utility rules are then removed.
+ */
+
+import type { Plugin, Root, Rule } from 'postcss'
+
+const PLUGIN_NAME = 'postcss-flatten-gradients'
+
+/** A gradient combo found on a DOM element. */
+export interface GradientCombo {
+  /** Generated class name to emit the flat rule for. */
+  className: string
+  /** The gradient utility class tokens present on the element. */
+  classes: string[]
+}
+
+type GradientFn = 'linear' | 'radial' | 'conic'
+
+interface UtilityInfo {
+  fn?: GradientFn
+  position?: string
+  from?: string
+  via?: string
+  to?: string
+  fromPosition?: string
+  viaPosition?: string
+  toPosition?: string
+}
+
+const GRADIENT_UTILITY_RE = /^(from|via|to)-|^bg-(linear|radial|conic)\b/
+const GENERATED_RE = /^bg-(linear|radial|conic)-gradient-/
+/**
+ * Color-interpolation method Tailwind appends to the position (e.g.
+ * `in oklab`, `in oklch longer hue`). It always trails the direction and
+ * is unsupported in email, so strip from `in <space>` to the end.
+ */
+const INTERP_RE = /(?:^|\s+)in\s+\S.*$/i
+
+/** Turn a single-class selector into its raw class token (`.from-\[\#f00\]` -> `from-[#f00]`). */
+function selectorToClass(selector: string): string | null {
+  const match = selector.match(/^\.((?:\\.|[^\s,>+~.])+)$/)
+  if (!match) return null
+  return match[1].replace(/\\(.)/g, '$1')
+}
+
+/** Strip the interpolation method so `to top in oklab` becomes `to top`. */
+function stripInterpolation(position: string): string {
+  return position.replace(INTERP_RE, '').trim()
+}
+
+export default (combos: GradientCombo[] = []): Plugin => {
+  return {
+    postcssPlugin: PLUGIN_NAME,
+
+    Once(root: Root) {
+      if (!combos.length) return
+
+      // Index every single-class gradient utility rule by its class token.
+      const utilities = new Map<string, UtilityInfo>()
+
+      root.walkRules((rule) => {
+        const cls = selectorToClass(rule.selector)
+        if (!cls || !GRADIENT_UTILITY_RE.test(cls)) return
+
+        const info = utilities.get(cls) ?? {}
+
+        // Only read declarations directly on the rule, skipping the
+        // nested @supports overrides Tailwind adds for oklab.
+        rule.each((node) => {
+          if (node.type !== 'decl') return
+          switch (node.prop) {
+            case '--tw-gradient-position':
+              info.position = node.value
+              break
+            case '--tw-gradient-from':
+              info.from = node.value
+              break
+            case '--tw-gradient-via':
+              info.via = node.value
+              break
+            case '--tw-gradient-to':
+              info.to = node.value
+              break
+            case '--tw-gradient-from-position':
+              info.fromPosition = node.value
+              break
+            case '--tw-gradient-via-position':
+              info.viaPosition = node.value
+              break
+            case '--tw-gradient-to-position':
+              info.toPosition = node.value
+              break
+            case 'background-image': {
+              const fn = node.value.match(/^(linear|radial|conic)-gradient\(/)
+              if (fn) info.fn = fn[1] as GradientFn
+              break
+            }
+          }
+        })
+
+        utilities.set(cls, info)
+      })
+
+      // Emit one flat rule per combo.
+      for (const combo of combos) {
+        const fnClass = combo.classes.find(c => /^bg-(linear|radial|conic)\b/.test(c))
+        if (!fnClass) continue
+
+        const fnInfo = utilities.get(fnClass)
+        const fn = fnInfo?.fn
+        if (!fn) continue
+
+        let from: string | undefined
+        let via: string | undefined
+        let to: string | undefined
+        let fromPosition: string | undefined
+        let viaPosition: string | undefined
+        let toPosition: string | undefined
+
+        for (const cls of combo.classes) {
+          const info = utilities.get(cls)
+          if (!info) continue
+          if (info.from !== undefined) from = info.from
+          if (info.via !== undefined) via = info.via
+          if (info.to !== undefined) to = info.to
+          if (info.fromPosition !== undefined) fromPosition = info.fromPosition
+          if (info.viaPosition !== undefined) viaPosition = info.viaPosition
+          if (info.toPosition !== undefined) toPosition = info.toPosition
+        }
+
+        // Tailwind defaults an unset from/to to transparent (#0000).
+        from = from ?? 'transparent'
+        to = to ?? 'transparent'
+
+        const direction = fnInfo?.position ? stripInterpolation(fnInfo.position) : ''
+
+        const stops: string[] = []
+        stops.push(fromPosition && fromPosition !== '0%' ? `${from} ${fromPosition}` : from)
+        if (via !== undefined) {
+          stops.push(viaPosition && viaPosition !== '50%' ? `${via} ${viaPosition}` : via)
+        }
+        stops.push(toPosition && toPosition !== '100%' ? `${to} ${toPosition}` : to)
+
+        const args = direction ? `${direction}, ${stops.join(', ')}` : stops.join(', ')
+
+        root.append({ selector: `.${combo.className}` } as Rule)
+        const created = root.last as Rule
+        created.append({ prop: 'background-image', value: `${fn}-gradient(${args})` })
+      }
+
+      // Remove the now-dead gradient utility rules.
+      root.walkRules((rule) => {
+        const cls = selectorToClass(rule.selector)
+        if (cls && !GENERATED_RE.test(cls) && GRADIENT_UTILITY_RE.test(cls)) {
+          rule.remove()
+        }
+      })
+    },
+  }
+}
+
+export const postcss = true

--- a/src/tests/transformers/tailwindcss.test.ts
+++ b/src/tests/transformers/tailwindcss.test.ts
@@ -297,4 +297,94 @@ describe('tailwindcss', () => {
       expect(result).toContain('color: red')
     })
   })
+
+  describe('gradients', () => {
+    const tw = '@import "tailwindcss" source(none);'
+
+    function gradient(classes: string): Promise<string> {
+      const html = `<style>${tw} @source inline("${classes}");</style><div class="${classes}">x</div>`
+      return run(html, undefined, { postcss: { removeAtRules: [] } })
+    }
+
+    it('flattens a linear gradient into a single email-safe declaration', async () => {
+      const result = await gradient('bg-linear-to-bl from-indigo-50 to-indigo-600')
+
+      expect(result).toContain('.bg-linear-gradient-to-bl-from-indigo-50-to-indigo-600')
+      expect(result).toContain('background-image: linear-gradient(to bottom left, #eef2ff, #4f39f6)')
+      // Rewrites the element to the single generated class
+      expect(result).toContain('<div class="bg-linear-gradient-to-bl-from-indigo-50-to-indigo-600">')
+      // No leftover Tailwind gradient machinery
+      expect(result).not.toContain('--tw-gradient')
+      expect(result).not.toContain('var(--tw-gradient-stops)')
+      expect(result).not.toContain('.from-indigo-50')
+    })
+
+    it('resolves via stops and keeps declared colors', async () => {
+      const result = await gradient('bg-linear-to-r from-red-500 via-yellow-400 to-green-600')
+
+      expect(result).toContain('background-image: linear-gradient(to right, #fb2c36, #fac800, #00a544)')
+    })
+
+    it('defaults a missing stop to transparent', async () => {
+      const result = await gradient('bg-linear-to-r from-indigo-500')
+
+      expect(result).toContain('linear-gradient(to right, #625fff, rgba(0, 0, 0, 0))')
+    })
+
+    it('writes transparent stops (normalized like all colors)', async () => {
+      const result = await gradient('bg-linear-to-r from-blue-500 to-transparent')
+
+      // lightningcss lowers the `transparent` keyword to rgba, same as
+      // everywhere else in Maizzle's output.
+      expect(result).toContain('linear-gradient(to right, #3080ff, rgba(0, 0, 0, 0))')
+    })
+
+    it('supports angle directions', async () => {
+      const result = await gradient('bg-linear-45 from-indigo-500 to-pink-500')
+
+      expect(result).toContain('linear-gradient(45deg, #625fff, #f6339a)')
+    })
+
+    it('strips the interpolation method from radial gradients', async () => {
+      const result = await gradient('bg-radial from-red-500 to-green-600')
+
+      // No `in oklab` interpolation keyword leaks into the gradient
+      expect(result).toContain('background-image: radial-gradient(#fb2c36, #00a544)')
+    })
+
+    it('supports conic gradients with an angle', async () => {
+      const result = await gradient('bg-conic-180 from-blue-500 to-pink-500')
+
+      expect(result).toContain('conic-gradient(from 180deg, #3080ff, #f6339a)')
+    })
+
+    it('keeps explicit non-default stop positions and omits defaults', async () => {
+      const result = await gradient('bg-linear-to-r from-indigo-500 from-25% to-pink-500 to-90%')
+
+      expect(result).toContain('linear-gradient(to right, #625fff 25%, #f6339a 90%)')
+    })
+
+    it('supports arbitrary color values', async () => {
+      const result = await gradient('bg-linear-to-r from-[#ff0000] to-[#0000ff]')
+
+      expect(result).toContain('linear-gradient(to right, red, #00f)')
+      expect(result).toContain('.bg-linear-gradient-to-r-from-ff0000-to-0000ff')
+    })
+
+    it('reuses one rule for elements sharing a gradient', async () => {
+      const html = `<style>${tw} @source inline("bg-linear-to-r from-red-500 to-blue-500");</style>`
+        + '<div class="bg-linear-to-r from-red-500 to-blue-500">a</div>'
+        + '<div class="bg-linear-to-r from-red-500 to-blue-500">b</div>'
+      const result = await run(html, undefined, { postcss: { removeAtRules: [] } })
+
+      const occurrences = result.split('.bg-linear-gradient-to-r-from-red-500-to-blue-500 {').length - 1
+      expect(occurrences).toBe(1)
+    })
+
+    it('preserves non-gradient classes on the element', async () => {
+      const result = await gradient('p-4 bg-linear-to-r from-red-500 to-blue-500 rounded')
+
+      expect(result).toMatch(/<div class="p-4 rounded bg-linear-gradient-to-r-from-red-500-to-blue-500">/)
+    })
+  })
 })

--- a/src/tests/transformers/tailwindcss.test.ts
+++ b/src/tests/transformers/tailwindcss.test.ts
@@ -386,5 +386,20 @@ describe('tailwindcss', () => {
 
       expect(result).toMatch(/<div class="p-4 rounded bg-linear-gradient-to-r-from-red-500-to-blue-500">/)
     })
+
+    it('keeps the gradient in the source position of the original utility', async () => {
+      // Later author CSS at equal specificity must still win, so the
+      // generated rule takes the utility's place rather than moving to
+      // the end of the stylesheet.
+      const html = `<style>${tw} @source inline("bg-linear-to-r from-red-500 to-blue-500");`
+        + ' .hero { background-image: url(fallback.png) }</style>'
+        + '<div class="hero bg-linear-to-r from-red-500 to-blue-500">x</div>'
+      const result = await run(html, undefined, { postcss: { removeAtRules: [] } })
+
+      const gradientAt = result.indexOf('.bg-linear-gradient-to-r-from-red-500-to-blue-500 {')
+      const authorAt = result.indexOf('.hero {')
+      expect(gradientAt).toBeGreaterThan(-1)
+      expect(gradientAt).toBeLessThan(authorAt)
+    })
   })
 })

--- a/src/transformers/tailwindcss.ts
+++ b/src/transformers/tailwindcss.ts
@@ -3,6 +3,7 @@ import type { ChildNode, Element } from 'domhandler'
 import { walk } from '../utils/ast/index.ts'
 import { decodeStyleEntities } from '../utils/decodeStyleEntities.ts'
 import { compileTailwindCss } from '../utils/compileTailwindCss.ts'
+import type { GradientCombo } from '../plugins/postcss/flattenGradients.ts'
 import type { MaizzleConfig } from '../types/config.ts'
 
 /**
@@ -57,6 +58,84 @@ function buildSourceDirectives(dom: ChildNode[], config: MaizzleConfig, fromDir:
   }
 
   return directives.join('\n')
+}
+
+const GRADIENT_FN_RE = /^bg-(linear|radial|conic)\b/
+const GRADIENT_GENERATED_RE = /^bg-(linear|radial|conic)-gradient-/
+const GRADIENT_STOP_RE = /^(from|via|to)-/
+
+/** Rank a stop class so generated names are stable regardless of author order. */
+function stopRank(cls: string): number {
+  const prefix = cls.startsWith('from-') ? 0 : cls.startsWith('via-') ? 1 : 2
+  const isPosition = /^(from|via|to)-\d+%$/.test(cls) ? 1 : 0
+  return prefix * 2 + isPosition
+}
+
+/** Sanitize a class token into a valid, readable CSS class name fragment. */
+function sanitize(token: string): string {
+  return token
+    .replace(/[[\]#()]/g, '')
+    .replace(/[/,.%\s]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+/**
+ * Detect Tailwind gradient class combinations on DOM elements.
+ *
+ * A gradient only works once its `bg-linear/radial/conic` direction class
+ * combines with `from-*`/`via-*`/`to-*` stops on the same element. This
+ * collects those per-element combos, rewrites each element to a single
+ * readable class (e.g. `bg-linear-gradient-to-bl-from-indigo-50-to-indigo-600`),
+ * and returns the combos so the flattenGradients plugin can emit one flat
+ * `background-image` rule per unique combo.
+ */
+function collectGradientCombos(dom: ChildNode[]): GradientCombo[] {
+  const bySignature = new Map<string, GradientCombo>()
+  const usedNames = new Map<string, string>()
+
+  walk(dom, (node) => {
+    const el = node as Element
+    const cls = el.attribs?.class
+    if (!cls) return
+
+    const tokens = cls.split(/\s+/).filter(Boolean)
+    const fnClass = tokens.find(t => GRADIENT_FN_RE.test(t) && !GRADIENT_GENERATED_RE.test(t))
+    if (!fnClass) return
+
+    const gradientClasses = tokens.filter(
+      t => (GRADIENT_FN_RE.test(t) && !GRADIENT_GENERATED_RE.test(t)) || GRADIENT_STOP_RE.test(t),
+    )
+    const stops = gradientClasses.filter(t => t !== fnClass).sort((a, b) => stopRank(a) - stopRank(b) || a.localeCompare(b))
+    const ordered = [fnClass, ...stops]
+    const signature = ordered.join(' ')
+
+    let combo = bySignature.get(signature)
+    if (!combo) {
+      const fn = fnClass.match(GRADIENT_FN_RE)![1]
+      const dirRemainder = fnClass.replace(new RegExp(`^bg-${fn}-?`), '')
+      const parts = [dirRemainder, ...stops].filter(Boolean).map(sanitize)
+      let name = `bg-${fn}-gradient${parts.length ? `-${parts.join('-')}` : ''}`
+
+      // Guard against sanitize collisions from distinct combos.
+      const existing = usedNames.get(name)
+      if (existing && existing !== signature) {
+        let n = 2
+        while (usedNames.has(`${name}-${n}`)) n++
+        name = `${name}-${n}`
+      }
+      usedNames.set(name, signature)
+
+      combo = { className: name, classes: ordered }
+      bySignature.set(signature, combo)
+    }
+
+    // Replace the gradient utilities with the single generated class.
+    const rest = tokens.filter(t => !gradientClasses.includes(t))
+    el.attribs.class = [...rest, combo.className].join(' ')
+  })
+
+  return [...bySignature.values()]
 }
 
 /**
@@ -117,6 +196,15 @@ export async function tailwindcss(dom: ChildNode[], config: MaizzleConfig, fileP
     ? buildSourceDirectives(dom, config, fromDir)
     : ''
 
+  /**
+   * Collect gradient combos and rewrite elements to single classes.
+   * Runs after source directives are built (so the utility classes are
+   * still scanned) and only feeds the first Tailwind style tag, whose
+   * `:root` holds the theme colors the flat rules reference.
+   */
+  const gradientCombos = hasTailwindStyles ? collectGradientCombos(dom) : []
+  const firstTailwindStyle = styleTags.findIndex(({ cssContent }) => usesTailwind(cssContent))
+
   for (let i = 0; i < styleTags.length; i++) {
     const { node, cssContent } = styleTags[i]
 
@@ -129,8 +217,10 @@ export async function tailwindcss(dom: ChildNode[], config: MaizzleConfig, fileP
       ? `${cssContent}\n${sourceDirectives}`
       : cssContent
 
+    const combos = i === firstTailwindStyle ? gradientCombos : []
+
     try {
-      const optimized = await compileTailwindCss(fullCss, config, `${fromPath}?style=${i}`)
+      const optimized = await compileTailwindCss(fullCss, config, `${fromPath}?style=${i}`, combos)
 
       // Replace the style tag's children with the compiled CSS
       node.children = [{

--- a/src/utils/compileTailwindCss.ts
+++ b/src/utils/compileTailwindCss.ts
@@ -5,13 +5,14 @@ import safeParser from 'postcss-safe-parser'
 import { transform } from 'lightningcss'
 import resolveProps from '../plugins/postcss/resolveProps.ts'
 import pruneVars from '../plugins/postcss/pruneVars.ts'
+import flattenGradients, { type GradientCombo } from '../plugins/postcss/flattenGradients.ts'
 import { tailwindCleanup } from '../plugins/postcss/tailwindCleanup.ts'
 import { mergeMediaQueries } from '../plugins/postcss/mergeMediaQueries.ts'
 import { quoteFontFamilies } from '../plugins/postcss/quoteFontFamilies.ts'
 import { resolveMaizzleImports } from '../plugins/postcss/resolveMaizzleImports.ts'
 import type { MaizzleConfig } from '../types/config.ts'
 
-export function createTailwindProcessor(config: MaizzleConfig) {
+export function createTailwindProcessor(config: MaizzleConfig, gradientCombos: GradientCombo[] = []) {
   return postcss([
     // Must run before @tailwindcss/postcss so it sees absolute import paths
     resolveMaizzleImports(),
@@ -20,6 +21,9 @@ export function createTailwindProcessor(config: MaizzleConfig) {
       transformAssetUrls: false,
       optimize: false,
     }),
+    // Flatten Tailwind's gradient var machinery into email-safe declarations
+    // before the var()/color resolution steps run.
+    flattenGradients(gradientCombos),
     resolveProps(),
     postcssCalc({}),
     pruneVars(),
@@ -57,8 +61,9 @@ export async function compileTailwindCss(
   cssInput: string,
   config: MaizzleConfig,
   from: string,
+  gradientCombos: GradientCombo[] = [],
 ): Promise<string> {
-  const processor = createTailwindProcessor(config)
+  const processor = createTailwindProcessor(config, gradientCombos)
   const result = await processor.process(cssInput, { from, parser: safeParser })
   const lowered = lowerCssSyntax(result.css)
   return optimizeTailwindCss(lowered, config)


### PR DESCRIPTION
## Problem

Tailwind v4 renders gradients as CSS-variable machinery split across separate utility rules:

```css
.bg-linear-to-bl { --tw-gradient-position: to bottom left;
                   background-image: linear-gradient(var(--tw-gradient-stops)); }
.from-indigo-50  { --tw-gradient-from: var(--color-indigo-50); --tw-gradient-stops: … }
.to-indigo-600   { --tw-gradient-to: var(--color-indigo-600); --tw-gradient-stops: … }
```

The variables only combine on an element carrying all three classes. Email clients don't support `var()` and Maizzle inlines styles, so `resolveProps`/`pruneVars` strip the cross-rule variables, leaving a dangling `background-image: linear-gradient(var(--tw-gradient-stops))` that renders nothing.

## Solution

`bg-linear-to-bl from-indigo-50 to-indigo-600` now compiles to a single inline-ready declaration:

```css
.bg-linear-gradient-to-bl-from-indigo-50-to-indigo-600 {
  background-image: linear-gradient(to bottom left, #eef2ff, #4f39f6);
}
```

The element is rewritten to that one readable class, so it stays clear even with inlining off.

- **`plugins/postcss/flattenGradients.ts`** (new) — runs after `@tailwindcss/postcss`, before var/color resolution. Given per-element combos, reads the `--tw-gradient-*` values off the utility rules and emits one flat `background-image` per combo, then removes the dead utility rules. Colors stay as `var(--color-*)` so the existing `resolveProps` + lightningcss steps convert them to hex — same path as every other Tailwind color.
- **`transformers/tailwindcss.ts`** — detects gradient combos on DOM elements (only where a `bg-linear/radial/conic` class is present), rewrites each element to a single generated class, passes combos into compile.
- **`utils/compileTailwindCss.ts`** — threads the combos through.

## Coverage

Linear (`to-*` directions + angles), radial, conic (+ angle); `from`/`via`/`to`; theme + arbitrary `[#hex]`/`[rgb()]` colors; opacity modifiers; explicit stop positions (defaults omitted); missing stops default to transparent. The `in oklab` interpolation keyword is stripped for email safety.

## Notes

- `transparent` lowers to `rgba(0, 0, 0, 0)` and colors carry a `lab()` fallback after the hex — both are existing framework-wide behaviors for all v4 colors, kept consistent for gradients.
- Adds 12 tests; full suite (1784) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting Tailwind gradient utilities into email-compatible background images.
  * Supports linear, radial, and conic gradients, including angles, transparent colors, arbitrary colors, and positioned stops.
  * Automatically combines gradient utilities into generated classes while preserving existing class behavior.
  * Supports shared gradient styles and deterministic output across source order.

* **Bug Fixes**
  * Removes unsupported gradient syntax and fills missing color endpoints with transparent values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->