### PR TITLE
feat(serve): keep command palette search across re-opens

### DIFF
--- a/src/server/ui/App.vue
+++ b/src/server/ui/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch, watchEffect } from 'vue'
+import { ref, computed, nextTick, onMounted, onUnmounted, watch, watchEffect } from 'vue'
 import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
 import { Monitor, CodeXml, Smartphone, ChevronDown, ArrowUp, ArrowDown, CornerDownLeft, Check, Search, FileCode, FileText, Code, BookText, MailQuestion, Moon, Sun } from '@lucide/vue'
 import SidebarClose from '@/components/SidebarClose.vue'
@@ -169,13 +169,23 @@ const modKey = isMac ? '⌘' : 'Ctrl'
 const commandOpen = ref(false)
 const commandSearch = ref('')
 
-watch(commandOpen, (open) => {
-  if (!open) commandSearch.value = ''
-})
+/**
+ * The search survives closing the palette so you can refine a query instead
+ * of retyping it (handy when hunting through hundreds of emails). It is only
+ * cleared when an actual command runs; selecting a template keeps the query
+ * so you can come back to the same list.
+ *
+ * Reka resets its filter whenever an item is selected, which would wipe the
+ * query, so template selection restores it on the next tick.
+ */
+function closeCommandPalette(clear = false) {
+  commandOpen.value = false
+  if (clear) commandSearch.value = ''
+}
 
 
 async function copyHtml() {
-  commandOpen.value = false
+  closeCommandPalette(true)
   const slug = route.params.template as string
   if (!slug) return
   const res = await fetch(`/__maizzle/render/${slug}`)
@@ -183,7 +193,7 @@ async function copyHtml() {
 }
 
 async function copyPlaintext() {
-  commandOpen.value = false
+  closeCommandPalette(true)
   const slug = route.params.template as string
   if (!slug) return
   const res = await fetch(`/__maizzle/plaintext/${slug}`)
@@ -191,7 +201,7 @@ async function copyPlaintext() {
 }
 
 async function copySource() {
-  commandOpen.value = false
+  closeCommandPalette(true)
   const slug = route.params.template as string
   if (!slug) return
   const res = await fetch(`/__maizzle/vue-source/${slug}`)
@@ -227,18 +237,21 @@ const filteredTemplatesCount = computed(() => {
   return count
 })
 
-
 function getFileName(path: string) {
   return path.split('/').pop() || path
 }
 
 function onCommandSelect(href: string) {
-  commandOpen.value = false
+  // Keep the query so navigating to a template doesn't lose the search;
+  // restore it after Reka's select-reset has wiped the filter.
+  const query = commandSearch.value
+  closeCommandPalette()
   router.push(href)
+  nextTick(() => { commandSearch.value = query })
 }
 
 function openExternal(url: string) {
-  commandOpen.value = false
+  closeCommandPalette(true)
   window.open(url, '_blank', 'noopener')
 }
 
@@ -286,7 +299,7 @@ function onWindowBlur() {
 }
 
 function toggleDarkMode() {
-  commandOpen.value = false
+  closeCommandPalette(true)
   darkMode.value = !darkMode.value
 }
 

--- a/src/server/ui/components/ui/command/Command.vue
+++ b/src/server/ui/components/ui/command/Command.vue
@@ -68,7 +68,10 @@ function filterItems() {
   filterState.filtered.count = itemCount
 }
 
-watch(() => filterState.search, () => {
+// Re-run on search change and whenever the item set changes, so a search
+// applied before items register (e.g. a restored query on re-open) filters
+// once those items mount instead of being stuck on "no results".
+watch([() => filterState.search, () => allItems.value.size], () => {
   filterItems()
 })
 

--- a/src/server/ui/components/ui/command/CommandInput.vue
+++ b/src/server/ui/components/ui/command/CommandInput.vue
@@ -27,12 +27,13 @@ const forwardedProps = useForwardProps(delegatedProps)
 
 const { filterState } = useCommand()
 
-// Sync external v-model → internal filter
+// Sync external v-model → internal filter (immediate so a preset value
+// populates the filter when the palette re-opens)
 watch(() => props.modelValue, (val) => {
   if (val !== undefined && val !== filterState.search) {
     filterState.search = val
   }
-})
+}, { immediate: true })
 
 // Sync internal filter → external v-model
 watch(() => filterState.search, (val) => {


### PR DESCRIPTION
## What

The dev-server command palette now **remembers the search text** when you close it, so refining a query means editing what's there instead of retyping from scratch — handy when working across many templates.

Clearing rules:
- **Running a command** (Emulate dark mode, Copy HTML/Plaintext/Vue source, Documentation, Can I Email) clears the search.
- **Selecting a template** (navigating to it) keeps the search.
- **Dismissing** the palette (Esc / click-away) keeps the search — whether or not it matched.

## Why

When building lots of emails you often reopen the palette to tweak the same search. Previously it reset to empty on every close, forcing a full retype.

## How

- **`App.vue`** — the search persists by default; clearing is driven by *which handler runs* (command handlers call `closeCommandPalette(true)`; template navigation restores the query after the palette's select-reset).
- **`CommandInput.vue`** — the external `v-model` → internal filter sync is now `immediate`, so a restored value actually populates the filter when the palette re-opens.
- **`Command.vue`** — `filterItems` now re-runs when the item set changes, not only on search change. A restored query is applied once on open, before the template items register; without this it stayed stuck on "No results found" even though the item existed.

## Verified

Drove the dev server manually:
- Template search + Enter-navigate → query preserved, and the re-opened palette shows the correct filtered result (not "No results").
- Non-matching text + Esc → preserved.
- Command match + Enter (dark mode, Documentation) → cleared.
- Normal typing/filtering unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved command-palette searches when navigating between templates or reopening the palette.
  * Restored filtering when command items finish loading.
  * Synchronized preset search text when the command palette opens.
  * Cleared searches appropriately after copy, external-link, and dark-mode actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->