### PR TITLE
perf(serve): cap command palette template results to keep it responsive

### DIFF
--- a/src/server/ui/App.vue
+++ b/src/server/ui/App.vue
@@ -211,20 +211,14 @@ async function copySource() {
   await navigator.clipboard.writeText(el.textContent || '')
 }
 
-const commandGrouped = computed(() => {
-  const groups: Record<string, Template[]> = {}
-
-  for (const t of templates.value) {
-    const parts = t.path.split('/')
-    const dir = parts.length > 1 ? parts.slice(0, -1).join('/') : '.'
-    if (!groups[dir]) groups[dir] = []
-    groups[dir].push(t)
-  }
-
-  return groups
-})
-
 const { contains } = useFilter({ sensitivity: 'base' })
+
+/**
+ * Cap how many template results render at once. Rendering every template as
+ * a CommandItem freezes the palette on the first keystroke in large projects
+ * (100s–1000s of templates), so we only render the matches, up to this many.
+ */
+const MAX_TEMPLATE_RESULTS = 50
 
 const filteredTemplatesCount = computed(() => {
   const tokens = commandSearch.value.split(/\s+/).filter(Boolean)
@@ -236,6 +230,25 @@ const filteredTemplatesCount = computed(() => {
   }
   return count
 })
+
+/** The matching templates (capped), grouped by directory, for rendering. */
+const filteredCommandGrouped = computed(() => {
+  const groups: Record<string, Template[]> = {}
+  const tokens = commandSearch.value.split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return groups
+  let count = 0
+  for (const t of templates.value) {
+    const haystack = `${getFileName(t.path)} ${t.path.split('/').join(' ')}`
+    if (!tokens.every(token => contains(haystack, token))) continue
+    const parts = t.path.split('/')
+    const dir = parts.length > 1 ? parts.slice(0, -1).join('/') : '.'
+    ;(groups[dir] ??= []).push(t)
+    if (++count >= MAX_TEMPLATE_RESULTS) break
+  }
+  return groups
+})
+
+const templatesTruncated = computed(() => filteredTemplatesCount.value > MAX_TEMPLATE_RESULTS)
 
 function getFileName(path: string) {
   return path.split('/').pop() || path
@@ -539,7 +552,7 @@ onUnmounted(() => {
 
         <!-- Templates -->
         <template v-if="commandSearch">
-          <CommandGroup v-for="(items, dir) in commandGrouped" :key="dir" :heading="String(dir)">
+          <CommandGroup v-for="(items, dir) in filteredCommandGrouped" :key="dir" :heading="String(dir)">
             <CommandItem
               v-for="t in items"
               :key="t.path"
@@ -568,7 +581,8 @@ onUnmounted(() => {
           Close
         </span>
         <span v-if="commandSearch" class="ml-auto">
-          {{ filteredTemplatesCount }} {{ filteredTemplatesCount === 1 ? 'result' : 'results' }}
+          <template v-if="templatesTruncated">Showing {{ MAX_TEMPLATE_RESULTS }} of {{ filteredTemplatesCount }} — refine to narrow</template>
+          <template v-else>{{ filteredTemplatesCount }} {{ filteredTemplatesCount === 1 ? 'result' : 'results' }}</template>
         </span>
       </div>
     </CommandDialog>

--- a/src/server/ui/App.vue
+++ b/src/server/ui/App.vue
@@ -220,35 +220,31 @@ const { contains } = useFilter({ sensitivity: 'base' })
  */
 const MAX_TEMPLATE_RESULTS = 50
 
-const filteredTemplatesCount = computed(() => {
-  const tokens = commandSearch.value.split(/\s+/).filter(Boolean)
-  if (tokens.length === 0) return 0
-  let count = 0
-  for (const t of templates.value) {
-    const haystack = `${getFileName(t.path)} ${t.path.split('/').join(' ')}`
-    if (tokens.every(token => contains(haystack, token))) count++
-  }
-  return count
-})
-
-/** The matching templates (capped), grouped by directory, for rendering. */
-const filteredCommandGrouped = computed(() => {
+/**
+ * Match templates against the search in a single pass: count every match for
+ * the footer, but only group the first MAX_TEMPLATE_RESULTS for rendering.
+ */
+const templateResults = computed(() => {
   const groups: Record<string, Template[]> = {}
   const tokens = commandSearch.value.split(/\s+/).filter(Boolean)
-  if (tokens.length === 0) return groups
-  let count = 0
+  if (tokens.length === 0) return { groups, total: 0 }
+  let total = 0
   for (const t of templates.value) {
     const haystack = `${getFileName(t.path)} ${t.path.split('/').join(' ')}`
     if (!tokens.every(token => contains(haystack, token))) continue
-    const parts = t.path.split('/')
-    const dir = parts.length > 1 ? parts.slice(0, -1).join('/') : '.'
-    ;(groups[dir] ??= []).push(t)
-    if (++count >= MAX_TEMPLATE_RESULTS) break
+    total++
+    if (total <= MAX_TEMPLATE_RESULTS) {
+      const parts = t.path.split('/')
+      const dir = parts.length > 1 ? parts.slice(0, -1).join('/') : '.'
+      ;(groups[dir] ??= []).push(t)
+    }
   }
-  return groups
+  return { groups, total }
 })
 
-const templatesTruncated = computed(() => filteredTemplatesCount.value > MAX_TEMPLATE_RESULTS)
+const filteredCommandGrouped = computed(() => templateResults.value.groups)
+const filteredTemplatesCount = computed(() => templateResults.value.total)
+const templatesTruncated = computed(() => templateResults.value.total > MAX_TEMPLATE_RESULTS)
 
 function getFileName(path: string) {
   return path.split('/').pop() || path


### PR DESCRIPTION
## Problem

In large projects (hundreds to thousands of templates), the dev-server command palette **freezes on the first keystroke**, then works fine afterward.

When the search becomes non-empty, the palette rendered **every** template as a `CommandItem` — reka's per-item filtering only hides non-matches *after* they mount. So the first character mounts one component instance per template (e.g. ~900), which blocks the main thread. Once mounted they stay warm, so subsequent typing feels fine.

## Fix

Render only the **matching** templates, capped at `MAX_TEMPLATE_RESULTS = 50`:

- `filteredCommandGrouped` filters + groups matches and stops at the cap, so at most 50 `CommandItem`s ever mount (and register with reka).
- The footer shows `Showing 50 of N — refine to narrow` when there are more matches, otherwise the normal result count. `filteredTemplatesCount` still scans everything for the true total (sub-millisecond string checks).

## Verified

Tested against a synthetic 900-template project:

- Broad `"template"` → 50 rendered + truncation hint, first-search interaction fast (no freeze).
- Specific search → narrows to the exact match; Enter navigates correctly.
- The persisted-search behavior still works with the large list.

## Tradeoff

Matches beyond the cap aren't shown until you refine — standard for command palettes (VS Code, Spotlight). Showing all matches would require full list virtualization, a much larger change to the reka `Listbox` integration; the cap is the minimal, robust win.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Command palette results now display only templates matching search terms in filenames and paths.
  * Matching templates are grouped by directory for easier browsing.
  * Results are limited to the first 50 items for faster, more manageable browsing.
  * A message indicates when additional results are omitted and suggests refining the search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->