### PR TITLE
feat(serve): reveal the active template in the sidebar

### DIFF
--- a/src/server/ui/App.vue
+++ b/src/server/ui/App.vue
@@ -129,16 +129,22 @@ watch(sidebarOpen, (open) => {
   localStorage.setItem('maizzle:sidebar', open ? 'open' : 'closed')
 })
 
-async function fetchTemplates() {
+async function fetchTemplates(revealActive = false) {
   const res = await fetch('/__maizzle/templates')
   templates.value = await res.json()
   loading.value = false
+  // On first load (e.g. after a dev-server restart) reveal the template being
+  // viewed so a restart doesn't leave you lost in a long sidebar.
+  if (revealActive && isPreviewRoute.value) {
+    await nextTick()
+    scrollSidebarToTemplate(route.path)
+  }
 }
 
-onMounted(fetchTemplates)
+onMounted(() => fetchTemplates(true))
 
 if ((import.meta as any).hot) {
-  (import.meta as any).hot.on('maizzle:templates-changed', fetchTemplates)
+  (import.meta as any).hot.on('maizzle:templates-changed', () => fetchTemplates())
 }
 
 const grouped = computed(() => {
@@ -250,13 +256,25 @@ function getFileName(path: string) {
   return path.split('/').pop() || path
 }
 
+/**
+ * Reveal a template in the sidebar. Jumping via the palette (or landing on a
+ * template after a dev-server restart) otherwise leaves the active item
+ * scrolled out of view in large projects.
+ */
+function scrollSidebarToTemplate(href: string) {
+  document.querySelector(`[data-sidebar-template="${href}"]`)?.scrollIntoView({ block: 'center' })
+}
+
 function onCommandSelect(href: string) {
   // Keep the query so navigating to a template doesn't lose the search;
   // restore it after Reka's select-reset has wiped the filter.
   const query = commandSearch.value
   closeCommandPalette()
   router.push(href)
-  nextTick(() => { commandSearch.value = query })
+  nextTick(() => {
+    commandSearch.value = query
+    scrollSidebarToTemplate(href)
+  })
 }
 
 function openExternal(url: string) {
@@ -386,8 +404,9 @@ onUnmounted(() => {
                     as-child
                     size="sm"
                     :is-active="isActive(t.href)"
+                    class="data-[active=true]:font-semibold"
                   >
-                    <RouterLink :to="t.href" class="truncate">
+                    <RouterLink :to="t.href" :data-sidebar-template="t.href" class="truncate">
                       <span class="mz-tpl-icon size-4 shrink-0 opacity-70" :class="t.path.endsWith('.md') ? 'mz-tpl-icon-md' : 'mz-tpl-icon-vue'" />
                       <span class="truncate">{{ t.name }}</span>
                     </RouterLink>

--- a/src/server/ui/App.vue
+++ b/src/server/ui/App.vue
@@ -262,7 +262,9 @@ function getFileName(path: string) {
  * scrolled out of view in large projects.
  */
 function scrollSidebarToTemplate(href: string) {
-  document.querySelector(`[data-sidebar-template="${href}"]`)?.scrollIntoView({ block: 'center' })
+  // CSS.escape the value — hrefs come from file paths and may contain
+  // characters that would otherwise break the attribute selector.
+  document.querySelector(`[data-sidebar-template=${CSS.escape(href)}]`)?.scrollIntoView({ block: 'center' })
 }
 
 function onCommandSelect(href: string) {


### PR DESCRIPTION
## What

In large projects the sidebar template list is long, and it was easy to lose track of which template you're viewing. This makes the dev UI reveal the active template:

- **Navigating via the command palette** now scrolls the sidebar to center the target template.
- **On first load** (which is what a dev-server restart triggers — a full page reload) it does the same, so a restart while viewing a template doesn't leave you lost.
- **Manual sidebar clicks are untouched** — no jump when you click within the sidebar yourself.
- The **active item** is a little easier to spot (`font-semibold`), while keeping the same subtle hover-tone background (no loud highlight).

## How

- Each sidebar link carries `:data-sidebar-template="t.href"`.
- A small `scrollSidebarToTemplate(href)` helper does `querySelector(...).scrollIntoView({ block: 'center' })`.
- `onCommandSelect` calls it after navigating; `fetchTemplates(revealActive)` calls it after the initial load only (the HMR `templates-changed` handler passes `false`, so editing/adding templates while you work doesn't yank the scroll).

## Verified

Tested against a large real project (900+ templates):
- Palette jump to a deep template → sidebar centers on it.
- Fresh load of a deep template URL (restart simulation) → sidebar centers on it.
- Light and dark both look right; existing palette search/persist/cap behavior unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - The active template now automatically scrolls into view when the preview loads.
  - Selecting a template from the command palette brings its sidebar entry into view.
  - The selected template is displayed with clearer, semibold styling.
  - Live updates retain existing behavior without causing unexpected scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->