### PR TITLE
feat(serve): match command palette search on template paths

### DIFF
--- a/src/server/ui/App.vue
+++ b/src/server/ui/App.vue
@@ -236,7 +236,9 @@ const templateResults = computed(() => {
   if (tokens.length === 0) return { groups, total: 0 }
   let total = 0
   for (const t of templates.value) {
-    const haystack = `${getFileName(t.path)} ${t.path.split('/').join(' ')}`
+    // Include the raw path so slash-style queries (e.g. "marketing/headers")
+    // match, alongside the space-split path for whitespace tokens.
+    const haystack = `${getFileName(t.path)} ${t.path} ${t.path.split('/').join(' ')}`
     if (!tokens.every(token => contains(haystack, token))) continue
     total++
     if (total <= MAX_TEMPLATE_RESULTS) {
@@ -578,7 +580,7 @@ onUnmounted(() => {
             >
               <span class="mz-tpl-icon size-3 shrink-0 opacity-70" :class="t.path.endsWith('.md') ? 'mz-tpl-icon-md' : 'mz-tpl-icon-vue'" />
               <span>{{ getFileName(t.path) }}</span>
-              <span class="sr-only">{{ ' ' + t.path.split('/').join(' ') }}</span>
+              <span class="sr-only">{{ ' ' + t.path + ' ' + t.path.split('/').join(' ') }}</span>
             </CommandItem>
           </CommandGroup>
         </template>


### PR DESCRIPTION
## What

The command palette can now be searched by path. Slash-style queries match the template hierarchy, which is what you'd expect when hunting through a large project:

- `marketing/headers` → lists all templates under `marketing/headers`
- `marketing/headers/4.with-avatar` → lists the templates in that folder

Previously these returned nothing, because the searchable text only had the path segments joined by spaces — so a query containing a `/` never matched.

## How

Include the **raw path** in the searchable text, alongside the existing space-split form:

- App-side `templateResults` haystack (decides which templates render).
- The palette item's `sr-only` text (reka filters each item by its `textContent`, so both layers need it to agree).

Whitespace tokens still work as before, so `marketing headers` and `headers avatar` behave the same as the slash form.

## Verified

Against a large real project:
- `marketing/headers` → 25 results
- `marketing/headers/4.with-avatar` → 2 results
- Regression: `with-avatar` → 2, `marketing headers` (space) → 25, `headers avatar` → 2 — unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Command-palette template search now supports slash-separated paths and filenames.
  - Search matching includes the full raw template path for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->