### PR TITLE
docs(skill): pin starter repo/branch and add i18n starter

### DIFF
--- a/skills/maizzle/SKILL.md
+++ b/skills/maizzle/SKILL.md
@@ -21,10 +21,11 @@ metadata:
 Build and send HTML emails that work in all major email clients, with Vue components and Tailwind CSS.
 
 ## Install
-Scaffold a project (interactive when `[starter]` and `[directory]` are omitted):
+Scaffold a project. The official Maizzle 6 starter is `maizzle/maizzle`, branch `master`:
 ```sh
-npx maizzle new [user/repo] [directory]
+npx maizzle new maizzle/maizzle#master [directory]
 ```
+For i18n (multi-language) emails, use `maizzle/starter-i18n#master`.
 
 Add to an existing project:
 ```sh

--- a/skills/maizzle/references/CLI.md
+++ b/skills/maizzle/references/CLI.md
@@ -3,7 +3,7 @@ Run via `npx maizzle …` or install globally with `npm i -g maizzle`.
 
 | Command | Description |
 |---|---|
-| `maizzle new [starter] [dir]` | Scaffold a project (interactive without args). Flags: `-i/--install`, `--pm <npm\|yarn\|pnpm\|bun>`. |
+| `maizzle new [starter#branch] [dir]` | Scaffold a project (interactive without args). Official v6 starter: `maizzle/maizzle#master`. Flags: `-i/--install`, `--pm <npm\|yarn\|pnpm\|bun>`. |
 | `maizzle serve` (alias `dev`) | Start the Vite dev server with HMR. Flags: `-c/--config <path>`, `-p/--port <n>`, `--host [addr]`. |
 | `maizzle build` | Production build. Flags: `-c/--config`, `-o/--output <dir>`, `--ext <extension>`, `--dir <path>` (source glob), `--pretty`, `--minify`, `--plaintext`. |
 | `maizzle prepare` | Regenerate `.maizzle/` IDE typings. Flag: `-c/--config`. |


### PR DESCRIPTION
Updates the Maizzle skill so agents scaffold from the right starter without guessing.

- Pin the official starter to `maizzle/maizzle#master` (default branch is `master`, not `main`) in both `SKILL.md` and `references/CLI.md`.
- Add the `maizzle/starter-i18n#master` starter for multi-language emails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Maizzle installation guidance to use the official v6 starter by default.
  * Added instructions for creating multi-language (i18n) email projects.
  * Documented branch selection in the `maizzle new` command, including the official v6 starter reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->