### PR TITLE
Scope Tailwind source scanning to each template's import closure

### DIFF
--- a/src/render/buildTemplate.ts
+++ b/src/render/buildTemplate.ts
@@ -87,7 +87,7 @@ export async function buildTemplate(
     const doctype = rendered.doctype ?? templateConfig.doctype ?? '<!DOCTYPE html>'
 
     if (templateConfig.useTransformers !== false) {
-      html = await runTransformers(html, templateConfig, absolutePath, doctype, rendered.tailwindBlocks)
+      html = await runTransformers(html, templateConfig, absolutePath, doctype, rendered.tailwindBlocks, rendered.sourceFiles)
     }
 
     html = await events.fireAfterTransform({ config: templateConfig, template, html })

--- a/src/render/createRenderer.ts
+++ b/src/render/createRenderer.ts
@@ -466,19 +466,29 @@ export async function createRenderer(
     const mods = server.moduleGraph.getModulesByFile(normalizePath(entryPath))
     if (!mods || mods.size === 0) return undefined
     const builtinsDir = normalizePath(frameworkComponentsDir)
-    const seen = new Set<string>()
+    const files = new Set<string>()
+    const visited = new Set<unknown>()
     const queue = [...mods]
     while (queue.length) {
       const m = queue.pop() as any
-      const file = m?.file ? normalizePath(m.file) : undefined
-      // Skip node_modules deps and virtual modules, but keep the framework's
-      // own built-in components (in node_modules when installed from npm).
-      if (!file || seen.has(file) || !isAbsolute(file)) continue
-      if (file.includes('node_modules') && !file.startsWith(builtinsDir)) continue
-      seen.add(file)
-      for (const dep of m.ssrImportedModules ?? m.importedModules ?? []) queue.push(dep)
+      if (!m || visited.has(m)) continue
+      visited.add(m)
+      const file = m.file ? normalizePath(m.file) : undefined
+      /**
+       * Prune node_modules subtrees (their imports can't be project
+       * files), but keep the framework's own built-in components
+       * (in node_modules when installed from npm).
+       */
+      if (file && file.includes('node_modules') && !file.startsWith(builtinsDir)) continue
+      if (file && isAbsolute(file)) files.add(file)
+      /**
+       * Traversal is tracked per module node, not per file, so virtual
+       * modules (no file) and query variants of an already-seen file
+       * still contribute their imports.
+       */
+      for (const dep of [...(m.ssrImportedModules ?? []), ...(m.importedModules ?? [])]) queue.push(dep)
     }
-    return [...seen]
+    return [...files]
   }
 
   return {

--- a/src/render/createRenderer.ts
+++ b/src/render/createRenderer.ts
@@ -1,4 +1,4 @@
-import { dirname, relative as relPath, resolve } from 'node:path'
+import { dirname, isAbsolute, relative as relPath, resolve } from 'node:path'
 import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { isLaravel } from '../utils/detect.ts'
@@ -6,7 +6,7 @@ import { rowSourceLocation } from './plugins/rowSourceLocation.ts'
 import { rawExtract } from './plugins/rawExtract.ts'
 import { codeBlockExtract } from './plugins/codeBlockExtract.ts'
 import { markdownExtract } from './plugins/markdownExtract.ts'
-import { createServer, mergeConfig, type InlineConfig, type Plugin } from 'vite'
+import { createServer, mergeConfig, normalizePath, type InlineConfig, type Plugin } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import Markdown from 'unplugin-vue-markdown/vite'
 import AutoImport from 'unplugin-auto-import/vite'
@@ -463,17 +463,18 @@ export async function createRenderer(
    * components are all reachable here. node_modules deps are skipped.
    */
   function collectSourceFiles(entryPath: string): string[] | undefined {
-    const mods = server.moduleGraph.getModulesByFile(entryPath)
+    const mods = server.moduleGraph.getModulesByFile(normalizePath(entryPath))
     if (!mods || mods.size === 0) return undefined
+    const builtinsDir = normalizePath(frameworkComponentsDir)
     const seen = new Set<string>()
     const queue = [...mods]
     while (queue.length) {
       const m = queue.pop() as any
-      const file: string | null | undefined = m?.file
+      const file = m?.file ? normalizePath(m.file) : undefined
       // Skip node_modules deps and virtual modules, but keep the framework's
       // own built-in components (in node_modules when installed from npm).
-      if (!file || seen.has(file) || !file.startsWith('/')) continue
-      if (file.includes('node_modules') && !file.startsWith(frameworkComponentsDir)) continue
+      if (!file || seen.has(file) || !isAbsolute(file)) continue
+      if (file.includes('node_modules') && !file.startsWith(builtinsDir)) continue
       seen.add(file)
       for (const dep of m.ssrImportedModules ?? m.importedModules ?? []) queue.push(dep)
     }

--- a/src/render/createRenderer.ts
+++ b/src/render/createRenderer.ts
@@ -41,6 +41,13 @@ export interface RenderedTemplate {
   plaintext?: RenderContext['plaintext']
   outputPath?: RenderContext['outputPath']
   tailwindBlocks?: RenderContext['tailwindBlocks']
+  /**
+   * Absolute paths of every project file in the template's module
+   * import closure (the template itself, its components, imported
+   * modules). Undefined for virtual/pre-compiled renders where no
+   * file entry exists.
+   */
+  sourceFiles?: string[]
 }
 
 export interface Renderer {
@@ -449,6 +456,30 @@ export async function createRenderer(
 
   const server = await createServer(finalConfig)
 
+  /**
+   * Walk the SSR module graph from a template entry and collect every
+   * project file it (transitively) imports — components resolved by
+   * unplugin appear as real static imports, so built-ins and userland
+   * components are all reachable here. node_modules deps are skipped.
+   */
+  function collectSourceFiles(entryPath: string): string[] | undefined {
+    const mods = server.moduleGraph.getModulesByFile(entryPath)
+    if (!mods || mods.size === 0) return undefined
+    const seen = new Set<string>()
+    const queue = [...mods]
+    while (queue.length) {
+      const m = queue.pop() as any
+      const file: string | null | undefined = m?.file
+      // Skip node_modules deps and virtual modules, but keep the framework's
+      // own built-in components (in node_modules when installed from npm).
+      if (!file || seen.has(file) || !file.startsWith('/')) continue
+      if (file.includes('node_modules') && !file.startsWith(frameworkComponentsDir)) continue
+      seen.add(file)
+      for (const dep of m.ssrImportedModules ?? m.importedModules ?? []) queue.push(dep)
+    }
+    return [...seen]
+  }
+
   return {
     async render(input: string | Component, config: MaizzleConfig, opts?: { source?: string; props?: Record<string, any> }): Promise<RenderedTemplate> {
       let component: Component
@@ -623,9 +654,14 @@ export async function createRenderer(
         html = html.replace(/<body([^>]*)>/, `<body$1>${previewHtml}`)
       }
 
+      const sourceFiles = typeof input === 'string' && !input.includes('<template') && !input.includes('<script')
+        ? collectSourceFiles(input)
+        : undefined
+
       return {
         html,
         doctype: renderContext.doctype,
+        sourceFiles,
         /**
          * Layer sfcConfig over config — sfcConfig is a partial override
          * emitted by composables (defineConfig, useTransformers, etc.).

--- a/src/render/createRenderer.ts
+++ b/src/render/createRenderer.ts
@@ -479,7 +479,7 @@ export async function createRenderer(
        * files), but keep the framework's own built-in components
        * (in node_modules when installed from npm).
        */
-      if (file && file.includes('node_modules') && !file.startsWith(builtinsDir)) continue
+      if (file && file.includes('/node_modules/') && !file.startsWith(`${builtinsDir}/`)) continue
       if (file && isAbsolute(file)) files.add(file)
       /**
        * Traversal is tracked per module node, not per file, so virtual

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -457,7 +457,7 @@ function getRendered(absolutePath: string, config: MaizzleConfig, renderer: Rend
         const doctype = rendered.doctype ?? templateConfig.doctype ?? '<!DOCTYPE html>'
 
         if (templateConfig.useTransformers !== false) {
-          html = await runTransformers(html, templateConfig, absolutePath, doctype, rendered.tailwindBlocks)
+          html = await runTransformers(html, templateConfig, absolutePath, doctype, rendered.tailwindBlocks, rendered.sourceFiles)
         }
 
         const rawHtml = await events.fireAfterTransform({ config: templateConfig, template, html })

--- a/src/tests/build.test.ts
+++ b/src/tests/build.test.ts
@@ -517,6 +517,66 @@ describe('build', () => {
     }
   })
 
+  describe('css.scopedSources', () => {
+    /**
+     * Card renders nothing (v-if="false"), so `uppercase` never reaches
+     * the rendered DOM — it can only be found by scanning the component
+     * file itself. `lowercase` lives in a project file outside the
+     * template's import closure.
+     */
+    function writeScopedProject(dir: string) {
+      symlinkSync(join(originalCwd, 'node_modules'), join(dir, 'node_modules'))
+
+      writeSfc(dir, 'components/Card.vue', `
+        <template>
+          <div v-if="false" class="uppercase">hidden</div>
+        </template>
+      `)
+
+      writeSfc(dir, 'stray.vue', `
+        <template>
+          <div class="lowercase">not imported anywhere</div>
+        </template>
+      `)
+
+      writeSfc(dir, 'emails/test.vue', `
+        <template>
+          <html>
+            <head>
+              <style>@import "tailwindcss";</style>
+            </head>
+            <body>
+              <div class="underline">Test</div>
+              <Card />
+            </body>
+          </html>
+        </template>
+      `)
+    }
+
+    it('scans only the template import closure by default', async () => {
+      writeScopedProject(tempDir)
+
+      const result = await build({ css: { inline: false, purge: false } })
+      const html = readFileSync(result.files[0], 'utf-8')
+
+      expect(html).toContain('.underline')
+      expect(html).toContain('.uppercase')
+      expect(html).not.toContain('.lowercase')
+    })
+
+    it('scans the whole project when scopedSources is false', async () => {
+      writeScopedProject(tempDir)
+
+      const result = await build({ css: { inline: false, purge: false, scopedSources: false } })
+      const html = readFileSync(result.files[0], 'utf-8')
+
+      expect(html).toContain('.underline')
+      expect(html).toContain('.uppercase')
+      expect(html).toContain('.lowercase')
+    })
+  })
+
   describe('plaintext', () => {
     it('generates .txt file alongside HTML with plaintext: true', async () => {
       writeSfc(tempDir, 'emails/welcome.vue', `

--- a/src/tests/render/createRenderer.test.ts
+++ b/src/tests/render/createRenderer.test.ts
@@ -69,6 +69,48 @@ describe('createRenderer', () => {
     expect(result.html).not.toContain('---->')
   })
 
+  it('collects sourceFiles through virtual modules and query variants', async () => {
+    /**
+     * deep.ts is only reachable through a virtual module, and Styled.vue's
+     * <style> block creates a query-variant module node for the same file.
+     * Both must survive the module graph traversal.
+     */
+    writeFileSync(join(tempDir, 'deep.ts'), 'export const token = "tracking-widest"\n')
+    writeFileSync(join(tempDir, 'Styled.vue'), '<template><div class="underline">s</div></template>\n<style>.x { color: red }</style>\n')
+    writeFileSync(join(tempDir, 'entry.vue'), [
+      '<script setup>',
+      "  import 'virtual:mz-test'",
+      "  import Styled from './Styled.vue'",
+      '</script>',
+      '<template><Styled /></template>',
+    ].join('\n'))
+
+    const config = await resolveConfig({
+      root: tempDir,
+      vite: {
+        plugins: [{
+          name: 'mz-test-virtual',
+          resolveId(id: string) {
+            if (id === 'virtual:mz-test') return '\0virtual:mz-test'
+          },
+          load(id: string) {
+            if (id === '\0virtual:mz-test') return `import '${join(tempDir, 'deep.ts')}'`
+          },
+        }],
+      },
+    })
+
+    const renderer = await createRenderer(config)
+    try {
+      const result = await renderer.render(join(tempDir, 'entry.vue'), config)
+      expect(result.sourceFiles).toContain(join(tempDir, 'entry.vue'))
+      expect(result.sourceFiles).toContain(join(tempDir, 'Styled.vue'))
+      expect(result.sourceFiles).toContain(join(tempDir, 'deep.ts'))
+    } finally {
+      await renderer.close()
+    }
+  })
+
   it('wraps a markdown code fence in a table with shiki highlighting', async () => {
     writeFileSync(join(tempDir, 'page.md'), '# Title\n\n```js\nconst x = 1\n```\n')
     const result = await render(join(tempDir, 'page.md'), { useTransformers: false })

--- a/src/tests/transformers/fixtures/scoped-source.html
+++ b/src/tests/transformers/fixtures/scoped-source.html
@@ -1,1 +1,2 @@
+<!doctype html>
 <div class="tracking-widest">Scoped source fixture</div>

--- a/src/tests/transformers/fixtures/scoped-source.html
+++ b/src/tests/transformers/fixtures/scoped-source.html
@@ -1,0 +1,1 @@
+<div class="tracking-widest">Scoped source fixture</div>

--- a/src/tests/transformers/tailwindComponent.test.ts
+++ b/src/tests/transformers/tailwindComponent.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { describe, it, expect } from 'vitest'
 import { tailwindComponent } from '../../transformers/tailwindComponent.ts'
 import { parse, serialize } from '../../utils/ast/index.ts'
@@ -33,5 +34,27 @@ describe('tailwindComponent', () => {
     const dom = parse('<head></head><!--mz-tw:a--><!--/mz-tw:b-->')
     const out = serialize(await tailwindComponent(dom, [{ id: 'a', css: '' }, { id: 'b', css: '' }], {}))
     expect(out).not.toContain('mz-tw:')
+  })
+
+  describe('css.scopedSources', () => {
+    const fixture = path.resolve(import.meta.dirname, 'fixtures/scoped-source.html')
+    const filePath = path.resolve(import.meta.dirname, 'test.html')
+
+    it('scans files from the template import closure by default', async () => {
+      // `tracking-widest` only exists in the fixture file, not in the block
+      const dom = parse('<head></head><!--mz-tw:b1--><div class="underline"></div><!--/mz-tw:b1-->')
+      const out = serialize(await tailwindComponent(dom, [{ id: 'b1' }], { postcss: { removeAtRules: [] } }, filePath, [fixture]))
+
+      expect(out).toContain('.underline')
+      expect(out).toContain('.tracking-widest')
+    })
+
+    it('ignores sourceFiles when scopedSources is false', async () => {
+      const dom = parse('<head></head><!--mz-tw:b1--><div class="underline"></div><!--/mz-tw:b1-->')
+      const out = serialize(await tailwindComponent(dom, [{ id: 'b1' }], { postcss: { removeAtRules: [] }, css: { scopedSources: false } }, filePath, [fixture]))
+
+      expect(out).toContain('.underline')
+      expect(out).not.toContain('.tracking-widest')
+    })
   })
 })

--- a/src/tests/transformers/tailwindcss.test.ts
+++ b/src/tests/transformers/tailwindcss.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
-import { tailwindcss } from '../../transformers/tailwindcss.ts'
+import { tailwindcss, rewriteImportsSourceNone } from '../../transformers/tailwindcss.ts'
 import { parse, serialize } from '../../utils/ast/index.ts'
 import type { MaizzleConfig } from '../../types/config.ts'
 
@@ -295,6 +295,80 @@ describe('tailwindcss', () => {
 
       expect(result).toContain('.foo')
       expect(result).toContain('color: red')
+    })
+  })
+
+  describe('rewriteImportsSourceNone', () => {
+    it('appends source(none) to a tailwindcss import', () => {
+      expect(rewriteImportsSourceNone('@import "tailwindcss";'))
+        .toBe('@import "tailwindcss" source(none);')
+    })
+
+    it('appends source(none) to a @maizzle/tailwindcss import', () => {
+      expect(rewriteImportsSourceNone('@import "@maizzle/tailwindcss";'))
+        .toBe('@import "@maizzle/tailwindcss" source(none);')
+    })
+
+    it('handles subpath imports', () => {
+      expect(rewriteImportsSourceNone('@import "tailwindcss/utilities";'))
+        .toBe('@import "tailwindcss/utilities" source(none);')
+    })
+
+    it('preserves existing modifiers', () => {
+      expect(rewriteImportsSourceNone('@import "tailwindcss/utilities" important;'))
+        .toBe('@import "tailwindcss/utilities" important source(none);')
+    })
+
+    it('skips imports that already have a source() modifier', () => {
+      expect(rewriteImportsSourceNone('@import "tailwindcss" source(none);'))
+        .toBe('@import "tailwindcss" source(none);')
+      expect(rewriteImportsSourceNone('@import "tailwindcss" source("../src");'))
+        .toBe('@import "tailwindcss" source("../src");')
+    })
+
+    it('ignores non-Tailwind imports', () => {
+      expect(rewriteImportsSourceNone('@import "./custom.css";'))
+        .toBe('@import "./custom.css";')
+    })
+  })
+
+  describe('css.scopedSources', () => {
+    const fixture = path.resolve(__dirname, 'fixtures/scoped-source.html')
+
+    it('scans files from the template import closure by default', async () => {
+      // `tracking-widest` only exists in the fixture file, not in the DOM
+      const html = '<style>@import "tailwindcss";</style><div class="underline">Test</div>'
+      const result = await tailwindcss(parse(html), { postcss: { removeAtRules: [] } }, path.resolve(__dirname, 'test.html'), [fixture]).then(serialize)
+
+      expect(result).toContain('.underline')
+      expect(result).toContain('.tracking-widest')
+      expect(result).toContain('letter-spacing:')
+    })
+
+    it('ignores sourceFiles when scopedSources is false', async () => {
+      const html = '<style>@import "tailwindcss" source(none);</style><div class="underline">Test</div>'
+      const result = await tailwindcss(parse(html), { postcss: { removeAtRules: [] }, css: { scopedSources: false } }, path.resolve(__dirname, 'test.html'), [fixture]).then(serialize)
+
+      expect(result).toContain('.underline')
+      expect(result).not.toContain('.tracking-widest')
+    })
+
+    it('falls back to non-scoped behavior when no sourceFiles are available', async () => {
+      const html = '<style>@import "tailwindcss" source(none);</style><div class="underline">Test</div>'
+      const result = await run(html, undefined, { postcss: { removeAtRules: [] } })
+
+      expect(result).toContain('.underline')
+      expect(result).not.toContain('.tracking-widest')
+    })
+
+    it('respects a user source() modifier in scoped mode', async () => {
+      // Import already pins source(none) — the rewrite must not touch it,
+      // and closure files are still added via @source directives.
+      const html = '<style>@import "tailwindcss" source(none);</style><div class="underline">Test</div>'
+      const result = await tailwindcss(parse(html), { postcss: { removeAtRules: [] } }, path.resolve(__dirname, 'test.html'), [fixture]).then(serialize)
+
+      expect(result).toContain('.underline')
+      expect(result).toContain('.tracking-widest')
     })
   })
 

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -61,6 +61,7 @@ export async function runTransformers(
   filePath?: string,
   doctype?: string,
   tailwindBlocks?: TailwindBlock[],
+  sourceFiles?: string[],
 ): Promise<string> {
   /**
    * Per-transformer skip map — only honored when useTransformers is an object.
@@ -107,11 +108,11 @@ export async function runTransformers(
 
   // 0.5. <Tailwind> component — compile per-block scoped CSS, inject into <head>
   if (tailwindBlocks?.length) {
-    dom = await tailwindComponent(dom, tailwindBlocks, effective, filePath)
+    dom = await tailwindComponent(dom, tailwindBlocks, effective, filePath, sourceFiles)
   }
 
   // 1. Tailwind CSS — always runs first
-  dom = await tailwindcss(dom, effective, filePath)
+  dom = await tailwindcss(dom, effective, filePath, sourceFiles)
 
   // 2. Safe class names
   if (enabled('safeSelectors')) dom = safeSelectorsDom(dom, effective.css)

--- a/src/transformers/tailwindComponent.ts
+++ b/src/transformers/tailwindComponent.ts
@@ -1,6 +1,7 @@
-import { resolve } from 'pathe'
+import { resolve, relative, dirname } from 'pathe'
 import type { ChildNode, Element, Comment } from 'domhandler'
 import { walk } from '../utils/ast/index.ts'
+import { rewriteImportsSourceNone } from './tailwindcss.ts'
 import { compileTailwindCss } from '../utils/compileTailwindCss.ts'
 import type { TailwindBlock } from '../composables/renderContext.ts'
 import type { MaizzleConfig } from '../types/config.ts'
@@ -29,6 +30,7 @@ export async function tailwindComponent(
   blocks: TailwindBlock[],
   config: MaizzleConfig,
   filePath?: string,
+  sourceFiles?: string[],
 ): Promise<ChildNode[]> {
   if (!blocks.length) return dom
 
@@ -85,10 +87,12 @@ export async function tailwindComponent(
    * the existing tailwindcss transformer out of recompiling
    * already-compiled CSS.
    */
+  const scoped = config.css?.scopedSources !== false && !!sourceFiles?.length
+
   for (const meta of map.values()) {
     if (meta.nested) continue
 
-    const cssInput = buildCssInput(meta.configCss, meta.classes)
+    const cssInput = buildCssInput(meta.configCss, meta.classes, scoped ? { sourceFiles: sourceFiles!, fromDir: dirname(fromPath) } : undefined)
     const css = (await compileTailwindCss(cssInput, config, `${fromPath}?tw=${meta.id}`)).trim()
     if (!css) continue
 
@@ -125,11 +129,31 @@ export async function tailwindComponent(
   return dom
 }
 
-function buildCssInput(configCss: string | undefined, classes: Set<string>): string {
-  const seed = configCss ?? DEFAULT_SEED
+function buildCssInput(
+  configCss: string | undefined,
+  classes: Set<string>,
+  scope?: { sourceFiles: string[]; fromDir: string },
+): string {
+  let seed = configCss ?? DEFAULT_SEED
 
-  if (!classes.size) return seed
+  const parts: string[] = []
 
-  const inline = [...classes].join(' ').replace(/"/g, '\\"')
-  return `${seed}\n@source inline("${inline}");`
+  /**
+   * Scoped mode: disable auto source detection in the user's config
+   * CSS and point the scanner at the template's import closure
+   * instead, mirroring the main tailwindcss transformer.
+   */
+  if (scope) {
+    seed = rewriteImportsSourceNone(seed)
+    for (const file of scope.sourceFiles) {
+      parts.push(`@source "${relative(scope.fromDir, file)}";`)
+    }
+  }
+
+  if (classes.size) {
+    const inline = [...classes].join(' ').replace(/"/g, '\\"')
+    parts.push(`@source inline("${inline}");`)
+  }
+
+  return parts.length ? `${seed}\n${parts.join('\n')}` : seed
 }

--- a/src/transformers/tailwindcss.ts
+++ b/src/transformers/tailwindcss.ts
@@ -27,17 +27,32 @@ function usesTailwind(css: string): boolean {
  *    expressions, and the template itself — Tailwind's scanner handles
  *    the actual class extraction from these raw values
  */
-function buildSourceDirectives(dom: ChildNode[], config: MaizzleConfig, fromDir: string): string {
+function buildSourceDirectives(dom: ChildNode[], config: MaizzleConfig, fromDir: string, sourceFiles?: string[]): string {
   const directives: string[] = []
 
-  // Exclude output dir and user-configured paths
-  const excludePaths = [
-    resolve(config.output?.path ?? 'dist'),
-    ...(config.css?.exclude ?? []).map(p => resolve(p)),
-  ]
+  const scoped = config.css?.scopedSources !== false && !!sourceFiles?.length
 
-  for (const p of excludePaths) {
-    directives.push(`@source not "${relative(fromDir, resolve(p))}";`)
+  if (scoped) {
+    /**
+     * Scoped mode: point Tailwind's scanner at exactly the files in
+     * this template's import closure instead of auto-detecting from
+     * the project root. Auto-detection is disabled by appending
+     * `source(none)` to the Tailwind import (see
+     * rewriteImportsSourceNone below).
+     */
+    for (const file of sourceFiles!) {
+      directives.push(`@source "${relative(fromDir, file)}";`)
+    }
+  } else {
+    // Exclude output dir and user-configured paths
+    const excludePaths = [
+      resolve(config.output?.path ?? 'dist'),
+      ...(config.css?.exclude ?? []).map(p => resolve(p)),
+    ]
+
+    for (const p of excludePaths) {
+      directives.push(`@source not "${relative(fromDir, resolve(p))}";`)
+    }
   }
 
   /**
@@ -139,6 +154,18 @@ function collectGradientCombos(dom: ChildNode[]): GradientCombo[] {
 }
 
 /**
+ * Append ` source(none)` to Tailwind imports so auto source detection
+ * is off and only our explicit `@source` directives apply. Skips
+ * imports that already carry a `source(...)` modifier.
+ */
+export function rewriteImportsSourceNone(css: string): string {
+  return css.replace(
+    /(@import\s+["'](?:@maizzle\/)?tailwindcss(?:\/[^"']*)?["'][^;]*);/g,
+    (match, stmt) => stmt.includes('source(') ? match : `${stmt} source(none);`,
+  )
+}
+
+/**
  * Tailwind CSS transformer.
  *
  * Compiles CSS inside <style> tags in the DOM using
@@ -146,7 +173,8 @@ function collectGradientCombos(dom: ChildNode[]): GradientCombo[] {
  *
  * Configures Tailwind sources to scan:
  * - Rendered class attributes (via `@source inline`) for all classes from all components
- * - User project files (via Tailwind's auto-detection from base/from path)
+ * - The template's module import closure (via `@source` directives), or user
+ *   project files (via Tailwind's auto-detection) when `css.scopedSources` is off
  *
  * User `@source` and `@source not directives` in style tags are preserved.
  * Source directives are only added to style tags that import Tailwind.
@@ -154,7 +182,7 @@ function collectGradientCombos(dom: ChildNode[]): GradientCombo[] {
  * Runs as the first transformer in the pipeline so that subsequent
  * transformers (inliner, purge, etc.) work with fully compiled CSS.
  */
-export async function tailwindcss(dom: ChildNode[], config: MaizzleConfig, filePath?: string): Promise<ChildNode[]> {
+export async function tailwindcss(dom: ChildNode[], config: MaizzleConfig, filePath?: string, sourceFiles?: string[]): Promise<ChildNode[]> {
   const styleTags: { node: Element; cssContent: string }[] = []
 
   walk(dom, (node) => {
@@ -193,8 +221,10 @@ export async function tailwindcss(dom: ChildNode[], config: MaizzleConfig, fileP
   // Only compute source directives if at least one style tag uses Tailwind
   const hasTailwindStyles = styleTags.some(({ cssContent }) => usesTailwind(cssContent))
   const sourceDirectives = hasTailwindStyles
-    ? buildSourceDirectives(dom, config, fromDir)
+    ? buildSourceDirectives(dom, config, fromDir, sourceFiles)
     : ''
+
+  const scoped = config.css?.scopedSources !== false && !!sourceFiles?.length
 
   /**
    * Collect gradient combos and rewrite elements to single classes.
@@ -213,8 +243,9 @@ export async function tailwindcss(dom: ChildNode[], config: MaizzleConfig, fileP
      * plain CSS doesn't need them and @tailwindcss/postcss would
      * leave the directives unconsumed in the output.
      */
-    const fullCss = usesTailwind(cssContent)
-      ? `${cssContent}\n${sourceDirectives}`
+    const usesTw = usesTailwind(cssContent)
+    const fullCss = usesTw
+      ? `${scoped ? rewriteImportsSourceNone(cssContent) : cssContent}\n${sourceDirectives}`
       : cssContent
 
     const combos = i === firstTailwindStyle ? gradientCombos : []

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -82,6 +82,17 @@ export interface CssConfig {
    */
   base?: string
   /**
+   * Scope Tailwind source scanning to each template's module import
+   * closure (the template file plus every component/module it actually
+   * uses) instead of scanning the whole project for every template.
+   *
+   * Set to `false` to restore whole-project scanning, e.g. when classes
+   * live in files Maizzle can't trace through imports.
+   *
+   * @default true
+   */
+  scopedSources?: boolean
+  /**
    * Remove unused CSS.
    *
    * Set to `true` to enable with defaults, or pass an options object.


### PR DESCRIPTION
This scopes Tailwind's `@source` scanner to each template's **import closure** (the template file plus every component and module it actually imports) instead of scanning the whole project for every single template. Enabled by default, with `css.scopedSources: false` as the escape hatch.

## Why

We render templates with Vite SSR, so the module graph already knows exactly which files each template uses. Previously we let Tailwind auto-detect sources from the project root, which meant every template's compile re-scanned the entire project. On large projects that's a lot of wasted work - most of the generated utilities came from unrelated templates and were thrown away by purge anyway.

Now we walk the SSR module graph after render, collect the closure, and feed it to Tailwind as explicit `@source` directives while disabling auto-detection with `source(none)`.

## Benchmark

Real-world project with 935 templates (mailviews.com as of today), built 3 times per config (`npm run build` = 3 sequential Maizzle builds). Medians of 3 runs:

| | whole-project scan | scoped (this PR) | speedup |
|---|---|---|---|
| total build | 132s | 53s | **2.5×** |
| production config | 42.6s | 17.8s | 2.4× |
| preview config | 43.8s | 17.5s | 2.5× |
| tailwind config | 33.5s | 13.9s | 2.4× |

Output parity on the same project: 3035 of 3110 files byte-identical. The 75 that differ only lose duplicated rules (the same utility picked up from multiple unrelated files) and gain grouped selectors (`.z, .sm { ... }`), so the scoped CSS is semantically identical and slightly smaller.

## Notes

- `RenderedTemplate` gains an optional `sourceFiles` array with the closure's absolute paths. It's `undefined` for virtual/pre-compiled renders, in which case everything falls back to the previous behavior.
- A user `source(...)` modifier on the Tailwind import is respected - we only append `source(none)` when there isn't one.
- `css.exclude` only applies in whole-project mode now, since scoped scanning doesn't need excludes.
- Docs PR for maizzle.com coming separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tailwind CSS now scans files imported by each template by default.
  * Added `css.scopedSources`; set it to `false` to scan the entire project.
  * Existing Tailwind source modifiers and inline source declarations remain supported.

* **Bug Fixes**
  * Improved handling of Tailwind imports, including subpaths and existing modifiers.
  * Preserved fallback behavior when source files cannot be determined.
  * Improved cross-platform source-file path handling.
  * Fixed source discovery through virtual modules and query-based imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->