### PR TITLE
fix: embedded Vite servers watch the entire host project

### DIFF
--- a/src/render/createRenderer.ts
+++ b/src/render/createRenderer.ts
@@ -284,6 +284,16 @@ export async function createRenderer(
    */
   const maizzleConfig: InlineConfig = {
     configFile: false,
+    /**
+     * Without an explicit root, Vite roots this SSR server at
+     * process.cwd() and its watcher recursively watches the entire host
+     * project — on large projects this exhausts inotify watch limits.
+     * The renderer only needs its watcher for component dirs (unplugin
+     * d.ts regeneration); template invalidation is driven externally via
+     * invalidateAll(). Root at the Maizzle root instead; component dirs
+     * outside it are re-added to the watcher after createServer below.
+     */
+    root: resolve(root),
     plugins: [
       rawExtract(),
       codeBlockExtract(),
@@ -455,6 +465,15 @@ export async function createRenderer(
     : maizzleConfig
 
   const server = await createServer(finalConfig)
+
+  /**
+   * With the narrowed root above, component dirs outside the Maizzle root
+   * are no longer covered by the root watch — add them explicitly so
+   * unplugin still sees add/unlink events.
+   */
+  for (const dir of [resolve(root, 'components'), ...dirSources.map(s => s.path)]) {
+    server.watcher.add(dir)
+  }
 
   /**
    * Walk the SSR module graph from a template entry and collect every

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -21,7 +21,7 @@ import { serveCompatibility } from './server/compatibility.ts'
 import { serveLint } from './server/linter.ts'
 import { sendEmail } from './server/email.ts'
 import { normalizeComponentSources } from './utils/componentSources.ts'
-import { createWatchedFileMatcher } from './utils/watchPaths.ts'
+import { createWatchedFileMatcher, deriveWatchRoots } from './utils/watchPaths.ts'
 import type { MaizzleConfig } from './types/index.ts'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -218,41 +218,39 @@ function maizzleDevPlugin(
         'locales/**',
       ]
 
-      const userWatchPaths = config.server?.watch ?? []
-      const watchPaths = [...defaultWatchPaths, ...userWatchPaths]
-      // Match against cwd, not config.root: the watched paths (maizzle/tailwind
-      // configs, locales) are project-root relative, and `watcher.add` below
-      // resolves them against cwd too. Using config.root would break matching
-      // when root points at a subdirectory (e.g. the Vite-plugin setup).
-      const isWatchedFile = createWatchedFileMatcher(watchPaths, process.cwd())
-
-      for (const watchPath of watchPaths) {
-        server.watcher.add(watchPath)
-      }
-
       /**
-       * With the dev UI directory as Vite root, the host cwd is no longer
-       * watched wholesale — add the trees Maizzle reacts to explicitly:
-       * template content, config root, component sources, and the static
-       * prefixes of the watch globs above. Directories, not globs: the
-       * server runs with Vite's default `disableGlobbing`, so globs passed
-       * to `watcher.add` are treated literally. Negated content patterns
-       * are excludes and produce no watch root.
+       * (Re)establish file watching for a resolved config: the watch globs
+       * themselves, the matcher used by the change handler below, and — with
+       * the dev UI directory as Vite root, the host cwd is no longer watched
+       * wholesale — the directories those globs and the template content live
+       * in (see deriveWatchRoots). Runs once here and again after a config
+       * reload, so content, components.source, root, and server.watch edits
+       * take effect without a server restart. Roots a reload leaves behind
+       * stay watched until restart — superfluous but harmless.
+       *
+       * Match against cwd, not config.root: the watched paths (maizzle/tailwind
+       * configs, locales) are project-root relative, and `watcher.add`
+       * resolves them against cwd too. Using config.root would break matching
+       * when root points at a subdirectory (e.g. the Vite-plugin setup).
        */
-      const globFreePrefix = (pattern: string) => {
-        const prefix = pattern.split(/[*?{]/)[0]
-        return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
-      }
-      const templateWatchRoots = [
-        ...(config.content ?? ['emails/**/*.vue']).filter(p => !p.startsWith('!')).map(globFreePrefix),
-        ...normalizeComponentSources(config.components?.source, process.cwd()).map(s => s.path),
-        ...(config.root ? [config.root] : []),
-        ...watchPaths.map(globFreePrefix),
-      ].filter(Boolean)
+      const applyWatchPaths = (cfg: typeof config) => {
+        const watchPaths = [...defaultWatchPaths, ...(cfg.server?.watch ?? [])]
+        const watchRoots = deriveWatchRoots({
+          content: cfg.content ?? ['emails/**/*.vue'],
+          componentDirs: normalizeComponentSources(cfg.components?.source, process.cwd()).map(s => s.path),
+          root: cfg.root,
+          watchPaths,
+          cwd: process.cwd(),
+        })
 
-      for (const watchRoot of new Set(templateWatchRoots)) {
-        server.watcher.add(watchRoot)
+        for (const path of [...watchPaths, ...watchRoots]) {
+          server.watcher.add(path)
+        }
+
+        return createWatchedFileMatcher(watchPaths, process.cwd())
       }
+
+      let isWatchedFile = applyWatchPaths(config)
 
       /**
        * Serialize watcher work onto one chain. The change handler closes and
@@ -300,6 +298,11 @@ function maizzleDevPlugin(
           // Re-register the new renderer so user-land render() calls don't keep
           // reusing the closed one (see setActiveRenderer above).
           setActiveRenderer(renderer)
+
+          // Re-establish watching against the reloaded config so moved
+          // content, components.source, root, or server.watch values keep
+          // emitting events without a server restart.
+          isWatchedFile = applyWatchPaths(config)
 
           /**
            * Push UI-relevant config bits so the dev UI reacts to live edits

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -112,6 +112,13 @@ export async function serve(options: ServeOptions = {}) {
      */
     root: devUIDir,
     appType: 'custom',
+    /**
+     * Vite derives `publicDir` from `root`, so keep serving the project's
+     * `public/` directory: templates reference images as `/logo.png`
+     * (the default `static.source` copies `public/**` on build) and
+     * the preview iframe resolves those against this server.
+     */
+    publicDir: resolve(process.cwd(), 'public'),
     plugins: [
       // Vue and Tailwind are only for the dev UI SPA, not for email templates
       vue(),

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -98,6 +98,20 @@ export async function serve(options: ServeOptions = {}) {
 
   const server = await createServer({
     configFile: false,
+    /**
+     * Root at the dev UI directory, not process.cwd(). With the host
+     * project as Vite root, the watcher recursively watches the entire
+     * host tree (vendor dirs, build output, …) — on large projects this
+     * exhausts inotify watch limits — and the host's own
+     * `server.watch.ignored` cannot reach this server. The UI is served
+     * via middleware + /@fs/ URLs and never needed the cwd root.
+     * `appType: 'custom'` keeps Vite from serving devUIDir/index.html
+     * itself, which would bypass the config-injecting middleware.
+     * The paths Maizzle actually reacts to are added explicitly in
+     * maizzleDevPlugin's configureServer.
+     */
+    root: devUIDir,
+    appType: 'custom',
     plugins: [
       // Vue and Tailwind are only for the dev UI SPA, not for email templates
       vue(),
@@ -214,6 +228,29 @@ function maizzleDevPlugin(
 
       for (const watchPath of watchPaths) {
         server.watcher.add(watchPath)
+      }
+
+      /**
+       * With the dev UI directory as Vite root, the host cwd is no longer
+       * watched wholesale — add the trees Maizzle reacts to explicitly:
+       * template content, config root, component sources, and the static
+       * prefixes of the watch globs above. Directories, not globs: the
+       * server runs with Vite's default `disableGlobbing`, so globs passed
+       * to `watcher.add` are treated literally.
+       */
+      const globFreePrefix = (pattern: string) => {
+        const prefix = pattern.split(/[*?{]/)[0]
+        return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
+      }
+      const templateWatchRoots = [
+        ...(config.content ?? ['emails/**/*.vue']).map(globFreePrefix),
+        ...normalizeComponentSources(config.components?.source, process.cwd()).map(s => s.path),
+        ...(config.root ? [config.root] : []),
+        ...watchPaths.map(globFreePrefix),
+      ].filter(Boolean)
+
+      for (const watchRoot of new Set(templateWatchRoots)) {
+        server.watcher.add(watchRoot)
       }
 
       /**

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -236,14 +236,15 @@ function maizzleDevPlugin(
        * template content, config root, component sources, and the static
        * prefixes of the watch globs above. Directories, not globs: the
        * server runs with Vite's default `disableGlobbing`, so globs passed
-       * to `watcher.add` are treated literally.
+       * to `watcher.add` are treated literally. Negated content patterns
+       * are excludes and produce no watch root.
        */
       const globFreePrefix = (pattern: string) => {
         const prefix = pattern.split(/[*?{]/)[0]
         return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
       }
       const templateWatchRoots = [
-        ...(config.content ?? ['emails/**/*.vue']).map(globFreePrefix),
+        ...(config.content ?? ['emails/**/*.vue']).filter(p => !p.startsWith('!')).map(globFreePrefix),
         ...normalizeComponentSources(config.components?.source, process.cwd()).map(s => s.path),
         ...(config.root ? [config.root] : []),
         ...watchPaths.map(globFreePrefix),

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -219,21 +219,24 @@ function maizzleDevPlugin(
       ]
 
       /**
-       * (Re)establish file watching for a resolved config: the watch globs
-       * themselves, the matcher used by the change handler below, and — with
-       * the dev UI directory as Vite root, the host cwd is no longer watched
-       * wholesale — the directories those globs and the template content live
-       * in (see deriveWatchRoots). Runs once here and again after a config
-       * reload, so content, components.source, root, and server.watch edits
-       * take effect without a server restart. Roots a reload leaves behind
-       * stay watched until restart — superfluous but harmless.
+       * (Re)establish file watching for a resolved config: the matcher used
+       * by the change handler below, and — with the dev UI directory as Vite
+       * root, the host cwd is no longer watched wholesale — the directories
+       * the watch globs and the template content live in (see
+       * deriveWatchRoots). Only derived roots are added to the watcher: the
+       * server runs with Vite's default `disableGlobbing`, so raw glob
+       * patterns would be treated as literal paths, and plain file paths
+       * survive derivation as themselves. Runs once here and again after a
+       * config reload, so content, components.source, root, and server.watch
+       * edits take effect without a server restart. Roots a reload leaves
+       * behind stay watched until restart — superfluous but harmless.
        *
        * Match against cwd, not config.root: the watched paths (maizzle/tailwind
        * configs, locales) are project-root relative, and `watcher.add`
        * resolves them against cwd too. Using config.root would break matching
        * when root points at a subdirectory (e.g. the Vite-plugin setup).
        */
-      const applyWatchPaths = (cfg: typeof config) => {
+      const applyWatchPaths = (cfg: MaizzleConfig) => {
         const watchPaths = [...defaultWatchPaths, ...(cfg.server?.watch ?? [])]
         const watchRoots = deriveWatchRoots({
           content: cfg.content ?? ['emails/**/*.vue'],
@@ -243,8 +246,8 @@ function maizzleDevPlugin(
           cwd: process.cwd(),
         })
 
-        for (const path of [...watchPaths, ...watchRoots]) {
-          server.watcher.add(path)
+        for (const watchRoot of watchRoots) {
+          server.watcher.add(watchRoot)
         }
 
         return createWatchedFileMatcher(watchPaths, process.cwd())

--- a/src/tests/serve.test.ts
+++ b/src/tests/serve.test.ts
@@ -200,4 +200,15 @@ describe('serve dev server', () => {
     expect(html).not.toContain('Original')
     expect(html).toContain('<!-- transformed -->')
   }, 30000)
+
+  it('serves the project public/ directory so template image paths resolve', async () => {
+    mkdirSync(join(tempDir, 'public'), { recursive: true })
+    writeFileSync(join(tempDir, 'public/logo.png'), 'png')
+
+    server = await serve({ port: 3157, silent: true })
+
+    const res = await fetch('http://localhost:3157/logo.png')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('png')
+  }, 30000)
 })

--- a/src/tests/utils/watchPaths.test.ts
+++ b/src/tests/utils/watchPaths.test.ts
@@ -82,6 +82,27 @@ describe('deriveWatchRoots', () => {
     expect(deriveWatchRoots({ ...base, watchPaths: ['*.json'] })).toEqual([cwd])
   })
 
+  it('stops the static prefix at bracket character classes', () => {
+    expect(deriveWatchRoots({ ...base, content: ['/project/locales/[a-z]/**'] }))
+      .toEqual(['/project/locales'])
+    expect(deriveWatchRoots({ ...base, watchPaths: ['locales/[a-z]/**/*.json'] }))
+      .toEqual(['locales'])
+  })
+
+  it('stops the static prefix at extglob openers', () => {
+    expect(deriveWatchRoots({ ...base, content: ['/project/emails/+(a|b)/**/*.vue'] }))
+      .toEqual(['/project/emails'])
+    expect(deriveWatchRoots({ ...base, content: ['/project/emails/@(de|en)/**/*.vue'] }))
+      .toEqual(['/project/emails'])
+    expect(deriveWatchRoots({ ...base, watchPaths: ['locales/!(draft)/**'] }))
+      .toEqual(['locales'])
+  })
+
+  it('keeps bare parentheses in directory names literal', () => {
+    expect(deriveWatchRoots({ ...base, watchPaths: ['locales (alt)/*.json'] }))
+      .toEqual(['locales (alt)'])
+  })
+
   it('drops negated watch patterns', () => {
     expect(deriveWatchRoots({ ...base, watchPaths: ['locales/**', '!locales/**/ignored.json'] }))
       .toEqual(['locales'])

--- a/src/tests/utils/watchPaths.test.ts
+++ b/src/tests/utils/watchPaths.test.ts
@@ -29,6 +29,23 @@ describe('createWatchedFileMatcher', () => {
     const matcher = createWatchedFileMatcher(['locales/**'], cwd)
     expect(matcher('/elsewhere/locales/en.json')).toBe(false)
   })
+
+  it('rejects files matched by a negated pattern', () => {
+    const matcher = createWatchedFileMatcher(['locales/**', '!locales/ignored.json'], cwd)
+    expect(matcher('/project/locales/en.json')).toBe(true)
+    expect(matcher('/project/locales/ignored.json')).toBe(false)
+  })
+
+  it('strips a leading "./" from negated patterns too', () => {
+    const matcher = createWatchedFileMatcher(['locales/**', '!./locales/ignored.json'], cwd)
+    expect(matcher('/project/locales/ignored.json')).toBe(false)
+  })
+
+  it('matches nothing when only negated patterns are given', () => {
+    const matcher = createWatchedFileMatcher(['!locales/**'], cwd)
+    expect(matcher('/project/emails/welcome.vue')).toBe(false)
+    expect(matcher('/project/locales/en.json')).toBe(false)
+  })
 })
 
 describe('deriveWatchRoots', () => {

--- a/src/tests/utils/watchPaths.test.ts
+++ b/src/tests/utils/watchPaths.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createWatchedFileMatcher } from '../../utils/watchPaths.ts'
+import { createWatchedFileMatcher, deriveWatchRoots } from '../../utils/watchPaths.ts'
 
 describe('createWatchedFileMatcher', () => {
   const cwd = '/project'
@@ -28,5 +28,53 @@ describe('createWatchedFileMatcher', () => {
   it('returns false for files outside the project root', () => {
     const matcher = createWatchedFileMatcher(['locales/**'], cwd)
     expect(matcher('/elsewhere/locales/en.json')).toBe(false)
+  })
+})
+
+describe('deriveWatchRoots', () => {
+  const cwd = '/project'
+  const base = { content: [], componentDirs: [], watchPaths: [], cwd }
+
+  it('uses the static prefix of resolved content globs', () => {
+    expect(deriveWatchRoots({ ...base, content: ['/project/emails/**/*.vue'] }))
+      .toEqual(['/project/emails'])
+  })
+
+  it('drops negated content patterns', () => {
+    expect(deriveWatchRoots({ ...base, content: ['/project/emails/**/*.vue', '!emails/**/skip.vue'] }))
+      .toEqual(['/project/emails'])
+  })
+
+  it('includes component dirs and root verbatim', () => {
+    expect(deriveWatchRoots({ ...base, componentDirs: ['/project/shared-components'], root: '/project/emails' }))
+      .toEqual(['/project/shared-components', '/project/emails'])
+  })
+
+  it('uses the static prefix of watch globs', () => {
+    expect(deriveWatchRoots({ ...base, watchPaths: ['locales/**', './translations/**/*.json'] }))
+      .toEqual(['locales', './translations'])
+  })
+
+  it('keeps plain file watch paths as-is', () => {
+    expect(deriveWatchRoots({ ...base, watchPaths: ['maizzle.config.ts'] }))
+      .toEqual(['maizzle.config.ts'])
+  })
+
+  it('falls back to cwd for watch patterns with no static prefix', () => {
+    expect(deriveWatchRoots({ ...base, watchPaths: ['**/*.json'] })).toEqual([cwd])
+    expect(deriveWatchRoots({ ...base, watchPaths: ['*.json'] })).toEqual([cwd])
+  })
+
+  it('drops negated watch patterns', () => {
+    expect(deriveWatchRoots({ ...base, watchPaths: ['locales/**', '!locales/**/ignored.json'] }))
+      .toEqual(['locales'])
+  })
+
+  it('deduplicates roots across sources', () => {
+    expect(deriveWatchRoots({
+      ...base,
+      content: ['/project/emails/**/*.vue', '/project/emails/**/*.md'],
+      root: '/project/emails',
+    })).toEqual(['/project/emails'])
   })
 })

--- a/src/utils/watchPaths.ts
+++ b/src/utils/watchPaths.ts
@@ -45,8 +45,16 @@ export function deriveWatchRoots(options: {
 }): string[] {
   const { content, componentDirs, root, watchPaths, cwd } = options
 
+  // Stop at any glob syntax across both glob backends in use — pathe's
+  // matchesGlob for the watched-file matcher (wildcards, ?, braces, bracket
+  // classes) and tinyglobby/picomatch for template listing (additionally
+  // extglobs: +(…), @(…), !(…), matched as two-char openers so bare
+  // parentheses in directory names stay literal). Splitting too late would
+  // leave a literal never-existing path as the root and silently lose
+  // coverage; splitting too early merely watches the parent directory,
+  // which still covers the target — so err on the side of splitting.
   const globFreePrefix = (pattern: string) => {
-    const prefix = pattern.split(/[*?{]/)[0]
+    const prefix = pattern.split(/[*?{[]|[+@!]\(/)[0]
     return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
   }
 

--- a/src/utils/watchPaths.ts
+++ b/src/utils/watchPaths.ts
@@ -5,12 +5,19 @@ import { matchesGlob, relative } from 'pathe'
  * chokidar matches any of the given globs. Patterns are interpreted as
  * project-relative; a leading `./` is stripped so user-supplied globs like
  * `./locales/**` behave identically to `locales/**`.
+ *
+ * Negated patterns (`!…`) are excludes: a file matches when it matches an
+ * include pattern and no exclude pattern. They must not reach `matchesGlob`
+ * as-is — it treats a lone negated pattern as "everything except", which
+ * under `some()` would make the predicate true for almost every file.
  */
 export function createWatchedFileMatcher(patterns: string[], cwd: string) {
-  const normalized = patterns.map(p => p.replace(/^\.\//, ''))
+  const stripDotSlash = (p: string) => p.replace(/^\.\//, '')
+  const includes = patterns.filter(p => !p.startsWith('!')).map(stripDotSlash)
+  const excludes = patterns.filter(p => p.startsWith('!')).map(p => stripDotSlash(p.slice(1)))
   return (file: string) => {
     const rel = relative(cwd, file)
-    return normalized.some(p => matchesGlob(rel, p))
+    return includes.some(p => matchesGlob(rel, p)) && !excludes.some(p => matchesGlob(rel, p))
   }
 }
 

--- a/src/utils/watchPaths.ts
+++ b/src/utils/watchPaths.ts
@@ -13,3 +13,40 @@ export function createWatchedFileMatcher(patterns: string[], cwd: string) {
     return normalized.some(p => matchesGlob(rel, p))
   }
 }
+
+/**
+ * Derive the directories the dev server watcher must cover explicitly now
+ * that its Vite root is the dev UI directory, not the project cwd: the
+ * static prefixes of the content globs, component source dirs, the Maizzle
+ * root, and the static prefixes of the watch globs. Directories, not globs —
+ * the dev server runs with Vite's default `disableGlobbing`, so globs passed
+ * to `watcher.add` are treated literally.
+ *
+ * Negated patterns are excludes and produce no watch root. A watch pattern
+ * with no static prefix (a bare `*.json`, or a glob starting with `**`)
+ * deliberately falls back to `cwd`:
+ * it asks for project-wide matching, and only a project-wide watch can honor
+ * it. Content patterns cannot hit that fallback — they arrive from
+ * `resolveConfig` already resolved against the (absolute) root.
+ */
+export function deriveWatchRoots(options: {
+  content: string[]
+  componentDirs: string[]
+  root?: string
+  watchPaths: string[]
+  cwd: string
+}): string[] {
+  const { content, componentDirs, root, watchPaths, cwd } = options
+
+  const globFreePrefix = (pattern: string) => {
+    const prefix = pattern.split(/[*?{]/)[0]
+    return prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
+  }
+
+  return [...new Set([
+    ...content.filter(p => !p.startsWith('!')).map(globFreePrefix),
+    ...componentDirs,
+    ...(root ? [root] : []),
+    ...watchPaths.filter(p => !p.startsWith('!')).map(p => globFreePrefix(p) || cwd),
+  ].filter(Boolean))]
+}


### PR DESCRIPTION
## Problem

Both embedded Vite servers — the dev UI (`serve.ts`) and the SSR renderer
(`render/createRenderer.ts`) — call `createServer()` without a `root`, so Vite
falls back to `process.cwd()`. In an embedded setup that is the host project,
and the dev watcher recursively watches the entire host tree. On a Laravel
project with a Rust build directory that is 117,771 inotify watches in
`vendor/` and build output, on top of the host's own dev server; on Linux this
exhausts `fs.inotify.max_user_watches` and other watchers start failing with
`ENOSPC`.

## Analysis

The host's `server.watch.ignored` does not reach these servers. The only
workaround is the `vite.server` passthrough, which is undocumented and easy to
miss.

Diagnosis is unusually hard: the watch calls come from Vite's bundled chokidar,
so stack traces are indistinguishable from the host server's own watcher, while
the host's `getWatched()` looks clean throughout. The gap only shows up when
comparing `getWatched()` against the kernel's inotify count.

Neither server needs the host root. The dev UI is served through middleware and
`/@fs/` URLs; the renderer's watcher exists only so unplugin sees component
add/unlink events and rewrites its `.d.ts`.

## Solution

Root the dev UI at `devUIDir` (with `appType: 'custom'`, so Vite's HTML
middleware does not bypass the config-injecting one) and the renderer at the
Maizzle root. Both then add the paths they actually react to explicitly:
content dirs, `config.root`, component sources, and the static prefixes of the
existing watch globs.

This is the smallest change that fixes the cause rather than the symptom.
`config.root` is already available at both call sites and already used for
`fs.allow`, `.d.ts` output and component resolution — the missing `root` reads
as an oversight, not a design decision. The alternative, threading the host's
ignore patterns through, would leave the servers rooted at the host project and
require every integration to opt in.

Impact on other projects is limited by construction. The watch scope narrows;
nothing that was watched for a reason stops being watched, because the paths
Maizzle reacts to are added back explicitly. `content` patterns arrive
absolutized by `resolveConfig`, so a leading-glob pattern like `**/*.vue`
resolves its watch root to the glob's parent — worst case the previous cwd-wide
watch, never a lost template watch. Standalone (non-embedded) use is unaffected
either way, since there `cwd` and the Maizzle root usually coincide.

## Measurements

Laravel host project, Vite 8.2.2, framework 6.1.2. Every `fs.watch` call
recorded with its path during a real server start, cross-checked against
`/proc/<pid>/fdinfo`:

| | before | after |
| --- | ---: | ---: |
| `fs.watch` calls | 123,244 | 4,320 |
| of those in `vendor/`, build output, `node_modules/`, `.git/` | 117,771 | 0 |
| Maizzle startup | ~11.9 s | ~1 s |

## Verification

- Dev UI returns 200 with the injected `__MAIZZLE_CONFIG__` and working `/@fs/` assets
- `/__maizzle/templates` responds
- A template created after server start is picked up by the watcher
- Full test suite passes (87 files, 1804 tests)

## Worth reviewing

- `publicDir` and `envDir` derive from `root`, so `<cwd>/public` is no longer
  statically served by the dev UI server.
- Projects relying on watcher events for files outside content, config root,
  component sources and the default watch paths now need to list them in
  `config.server.watch` — the documented mechanism for exactly that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development server file watching to avoid monitoring unrelated project files.
  * Reduced the risk of reaching system file-watch limits in large projects.
  * Preserved live updates for templates, components, configuration files, and configured watch paths.
  * Ensured watch settings continue working after configuration changes without restarting the server.
  * Improved handling of excluded, negated, and complex watch patterns.
  * Prevented the development server from serving unintended host-project entry pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->